### PR TITLE
E6x - add pattern loop

### DIFF
--- a/test/effects.js
+++ b/test/effects.js
@@ -504,3 +504,32 @@ exports['test E5x finetune override'] = function(assert) {
   var f2 = 12 * 128 * Math.log(ch.doff / f0) / Math.log(2);
   assert.equal(f2.toFixed(2), "131.00", "E5f finetune +127");
 };
+
+exports['test E60 loop twice with set beginning'] = function(assert) {
+  var xm = testdata.resetXMData(2);
+
+  xm.patterns[0] = [
+    [[60, 1, -1, 0, 0], [-1, -1, -1, 0x0, 0x00]], // 0  0
+    [[62, 1, -1, 0, 0], [-1, -1, -1, 0xE, 0x60]], // 1   1  4  7
+    [[64, 1, -1, 0, 0], [-1, -1, -1, 0x0, 0x00]], // 2    2  5  8
+    [[65, 1, -1, 0, 0], [-1, -1, -1, 0xE, 0x62]], // 3     3  6  9
+    [[66, 1, -1, 0, 0], [-1, -1, -1, 0x0, 0x00]]  // 4            10
+  ];                                              // ^r t->
+
+  //  C-5 1  --  ---     --  --  --  --- |
+  //  D-5 1  --  ---     --  --  --  E60 | set repeat start
+  //  E-5 1  --  ---     --  --  --  --- |
+  //  F-5 1  --  ---     --  --  --  E62 | goto repeate start twice
+  //  G-5 1  --  ---     --  --  --  --- |
+
+  xm.tempo = 2;
+  var rowProgression = []
+  for(var i = 0; i < 11; i++) {
+    XMPlayer.nextTick();
+    XMPlayer.nextTick();
+    rowProgression.push(XMPlayer.cur_row)
+  }
+
+  assert.deepEqual(rowProgression, [0,1,2,3, 1,2,3, 1,2,3,4], "row 10"
+  );
+}

--- a/test/testdata.js
+++ b/test/testdata.js
@@ -1,7 +1,8 @@
 var XMPlayer = window.XMPlayer;
 
 // set up basic blank single-channel, single-pattern XM
-exports.resetXMData = function() {
+exports.resetXMData = function(channels) {
+  if(typeof channels == 'undefined') { channels =  1 }
   var xm = {};
   window.XMPlayer.xm = xm;
   xm.channelinfo = [];
@@ -11,22 +12,24 @@ exports.resetXMData = function() {
   xm.flags = 1;
   xm.tempo = 3;
   xm.bpm = 125;
-  xm.channelinfo.push({
-    number: 0,
-    filterstate: new Float32Array(3),
-    vol: 0,
-    pan: 128,
-    period: 1920 - 48*16,
-    vL: 0, vR: 0,
-    vLprev: 0, vRprev: 0,
-    mute: 0,
-    volE: 0, panE: 0,
-    retrig: 0,
-    vibratopos: 0,
-    vibratodepth: 1,
-    vibratospeed: 1,
-    vibratotype: 0,
-  });
+  for(var i = 0; i < channels; i++){
+    xm.channelinfo.push({
+      number: i,
+      filterstate: new Float32Array(3),
+      vol: 0,
+      pan: 128,
+      period: 1920 - 48*16,
+      vL: 0, vR: 0,
+      vLprev: 0, vRprev: 0,
+      mute: 0,
+      volE: 0, panE: 0,
+      retrig: 0,
+      vibratopos: 0,
+      vibratodepth: 1,
+      vibratospeed: 1,
+      vibratotype: 0,
+    });
+  }
   xm.songpats = [0];
   // 1 channel, 2 row blank pattern
   xm.patterns = [

--- a/xm.js
+++ b/xm.js
@@ -132,15 +132,13 @@ function setCurrentPattern() {
 }
 
 function nextRow() {
-  if(typeof player.goto_row == "undefined") {
-    player.cur_row++;
-  } else {
-    player.cur_row = player.goto_row;
-    delete player.goto_row;
-  }
+  if(typeof player.next_row === "undefined") { player.next_row = player.cur_row + 1; }
+  player.cur_row = player.next_row;
+  player.next_row++;
 
   if (player.cur_pat == -1 || player.cur_row >= player.xm.patterns[player.cur_pat].length) {
     player.cur_row = 0;
+    player.next_row = 1;
     player.cur_songpos++;
     if (player.cur_songpos >= player.xm.songpats.length)
       player.cur_songpos = player.xm.song_looppos;

--- a/xm.js
+++ b/xm.js
@@ -132,7 +132,13 @@ function setCurrentPattern() {
 }
 
 function nextRow() {
-  player.cur_row++;
+  if(typeof player.goto_row == "undefined") {
+    player.cur_row++;
+  } else {
+    player.cur_row = player.goto_row;
+    delete player.goto_row;
+  }
+
   if (player.cur_pat == -1 || player.cur_row >= player.xm.patterns[player.cur_pat].length) {
     player.cur_row = 0;
     player.cur_songpos++;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -143,7 +143,7 @@ function eff_t0_d(ch, data) {  // pattern jump
   if (player.cur_songpos >= player.xm.songpats.length)
     player.cur_songpos = player.xm.song_looppos;
   player.cur_pat = player.xm.songpats[player.cur_songpos];
-  player.cur_row = (data >> 4) * 10 + (data & 0x0f) - 1;
+  player.next_row = (data >> 4) * 10 + (data & 0x0f);
 }
 
 function eff_t0_e(ch, data) {  // extended effects!
@@ -166,18 +166,16 @@ function eff_t0_e(ch, data) {  // extended effects!
       if (data == 0) {
         ch.loopstart = player.cur_row
       } else {
-        if (typeof ch.loopend === 'undefined') {
+        if (typeof ch.loopend === "undefined") {
           ch.loopend = player.cur_row
           ch.loopremaining = data
         }
         if(ch.loopremaining !== 0) {
           ch.loopremaining--
-          player.goto_row = ch.loopstart || 0
-        }
-        else {
+          player.next_row = ch.loopstart || 0
+        } else {
           delete ch.loopend
           delete ch.loopstart
-          delete player.goto_row
         }
       }
       break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -162,6 +162,25 @@ function eff_t0_e(ch, data) {  // extended effects!
     case 5:  // finetune
       ch.fine = (data<<4) + data - 128;
       break;
+    case 6:  // pattern loop
+      if (data == 0) {
+        ch.loopstart = player.cur_row
+      } else {
+        if (typeof ch.loopend === 'undefined') {
+          ch.loopend = player.cur_row
+          ch.loopremaining = data
+        }
+        if(ch.loopremaining !== 0) {
+          ch.loopremaining--
+          player.goto_row = ch.loopstart || 0
+        }
+        else {
+          delete ch.loopend
+          delete ch.loopstart
+          delete player.goto_row
+        }
+      }
+      break;
     case 8:  // panning
       ch.pan = data * 0x11;
       break;


### PR DESCRIPTION
Add pattern loop `E6x`

I'm hesitant to submit this PR for a few reasons, but I want to start the discussion:
- it references a global `player` object from within the `eff_t0_e` function
- it required changing the logic in `nextRow`
- it adds multiple variables to the top level of the `channel` object

Would you prefer effects set a flag on player or player read through channels and look for effects flags?

If it stays this way, should I clear the `goto_row` variable in `stop` or `init`?

I'm not too familiar with this file format, so if there's another way you'd prefer this implemented I'd happily make changes to the PR.