### PR TITLE
Oscillator fixes for older Safari browsers

### DIFF
--- a/xm.js
+++ b/xm.js
@@ -937,9 +937,8 @@ function play() {
     // hack to get iOS to play anything
     var temp_osc = player.audioctx.createOscillator();
     temp_osc.connect(player.audioctx.destination);
-    if (temp_osc.noteOn) temp_osc.start = temp_osc.noteOn;
-    temp_osc.start(0);
-    temp_osc.stop();
+    !!temp_osc.start ? temp_osc.start(0) : temp_osc.noteOn(0);
+    !!temp_osc.stop ? temp_osc.stop(0) : temp_osc.noteOff(0);
     temp_osc.disconnect();
   }
   player.playing = true;


### PR DESCRIPTION
2 fixes in 1:
- In some older Safari browsers the parameter for the oscillator's stop/noteOff-function is mandatory (if this isn't set an error occurs and the oscillator won't stop). So I set it to 0 which is the default case in other browsers.
- Some older Safari browsers have a noteOff- instead of a stop-function for the oscillator (similar to the noteOn-case which is already implemented). I've added this and use a tenary operator to select the right function instead of copying it.