### PR TITLE
Implement missing XM effects and improve mixing/spec compliance

### DIFF
--- a/xm.js
+++ b/xm.js
@@ -268,7 +268,7 @@ function nextRow() {
           // with portamento; key-off must keep release active
           ch.envtick = 0;
           ch.release = 0;
-          ch.fadeOutVol = 65536;
+          ch.fadeOutVol = 32768;
           ch.env_vol = new EnvelopeFollower(inst.env_vol);
           ch.env_pan = new EnvelopeFollower(inst.env_pan);
         }
@@ -280,7 +280,7 @@ function nextRow() {
       if (ch.effect != 9) ch.off = 0;
       ch.release = 0;
       ch.envtick = 0;
-      ch.fadeOutVol = 65536;
+      ch.fadeOutVol = 32768;
       ch.env_vol = new EnvelopeFollower(inst.env_vol);
       ch.env_pan = new EnvelopeFollower(inst.env_pan);
       if (ch.note) {
@@ -304,7 +304,7 @@ function triggerNote(ch) {
   if (ch.effect != 9) ch.off = 0;
   ch.release = 0;
   ch.envtick = 0;
-  ch.fadeOutVol = 65536;
+  ch.fadeOutVol = 32768;
   ch.env_vol = new EnvelopeFollower(inst.env_vol);
   ch.env_pan = new EnvelopeFollower(inst.env_pan);
   if (d.note) {
@@ -459,7 +459,7 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
     sample_end = loopstart + looplen;
   }
   var volE = ch.volE / 64.0;    // current volume envelope
-  var fadeOut = (ch.fadeOutVol !== undefined ? ch.fadeOutVol : 65536) / 65536.0;
+  var fadeOut = (ch.fadeOutVol !== undefined ? ch.fadeOutVol : 32768) / 32768.0;
   // panning formula from spec: FinalPan = Pan + ((EnvPan-32)*(128-|Pan-128|)/32)
   var finalPan = ch.pan + (ch.panE - 32) * (128 - Math.abs(ch.pan - 128)) / 32;
   var p = finalPan - 128;  // center around 0
@@ -686,7 +686,7 @@ function load(arrayBuf) {
       vLprev: 0, vRprev: 0,
       mute: 0,
       volE: 0, panE: 0,
-      fadeOutVol: 65536,
+      fadeOutVol: 32768,
       retrig: 0,
       autovibratopos: 0,
       autovibratosweep: 0,

--- a/xm.js
+++ b/xm.js
@@ -493,6 +493,7 @@ EnvelopeFollower.prototype.Tick = function(release) {
 function nextTick() {
   player.cur_tick++;
   var j, ch;
+  var pattDelayTick = false;
   for (j = 0; j < player.xm.nchan; j++) {
     ch = player.xm.channelinfo[j];
     ch.periodoffset = 0;
@@ -503,6 +504,8 @@ function nextTick() {
       if (player.patterndelay > 0) {
         player.patterndelay--;
         player.cur_tick = 0;
+        // FT2: during pattern delay repeats, tick-0 runs non-zero effects
+        pattDelayTick = true;
       } else {
         player.patterndelay = undefined;
         player.cur_tick = 0;
@@ -516,7 +519,7 @@ function nextTick() {
   for (j = 0; j < player.xm.nchan; j++) {
     ch = player.xm.channelinfo[j];
     var inst = ch.inst;
-    if (player.cur_tick !== 0) {
+    if (player.cur_tick !== 0 || pattDelayTick) {
       if(ch.voleffectfn) ch.voleffectfn(ch);
       if(ch.effectfn) ch.effectfn(ch);
     }

--- a/xm.js
+++ b/xm.js
@@ -1173,6 +1173,7 @@ function load(arrayBuf) {
       inst.samplemap = samplemap;
       inst.samples = samps;
       inst.vol_fadeout = vol_fadeout;
+      inst.env_vol_flags = env_vol_type;  // original file flags for Lxx FT2 bug
       inst.vib_type = vib_type;
       inst.vib_sweep = vib_sweep;
       inst.vib_depth = vib_depth;

--- a/xm.js
+++ b/xm.js
@@ -367,8 +367,19 @@ function nextTick() {
     ch.voloffset = 0;
   }
   if (player.cur_tick >= player.xm.tempo) {
-    player.cur_tick = 0;
-    nextRow();
+    if (player.patterndelay !== undefined) {
+      if (player.patterndelay > 0) {
+        player.patterndelay--;
+        player.cur_tick = 0;
+      } else {
+        player.patterndelay = undefined;
+        player.cur_tick = 0;
+        nextRow();
+      }
+    } else {
+      player.cur_tick = 0;
+      nextRow();
+    }
   }
   for (j = 0; j < player.xm.nchan; j++) {
     ch = player.xm.channelinfo[j];

--- a/xm.js
+++ b/xm.js
@@ -551,7 +551,10 @@ function nextTick() {
       avPeriodOffset = (autoVibVal * autoVibAmp) / 65536;
       ch.autovibratopos = (ch.autovibratopos + inst.vib_rate) & 255;
     }
-    updateChannelPeriod(ch, ch.period + ch.periodoffset + avPeriodOffset);
+    var finalPeriod = ch.period + ch.periodoffset + avPeriodOffset;
+    // FT2: clamp period — if >= 32000 (8000 in JS 1/4-scale), set to 0 (silence)
+    if (finalPeriod >= 8000) finalPeriod = 0;
+    updateChannelPeriod(ch, finalPeriod);
   }
 }
 

--- a/xm.js
+++ b/xm.js
@@ -419,6 +419,11 @@ function nextRow() {
       if (eff_t0) eff_t0(ch, ch.effectdata);
     }
   }
+  // FT2: resolve E6x pattern loop (pBreakFlag) before Bxx/Dxx
+  if (player.pBreakFlag) {
+    player.pBreakFlag = false;
+    player.next_row = player.pBreakPos;
+  }
   // resolve deferred Bxx/Dxx position jumps after all channels processed
   if (player.posJumpFlag) {
     if (player.posJumpPos !== undefined) {
@@ -436,8 +441,8 @@ function nextRow() {
     }
     player.posJumpFlag = false;
     player.posJumpPos = undefined;
-    player.pBreakPos = undefined;
   }
+  player.pBreakPos = undefined;
 }
 
 function triggerNote(ch) {

--- a/xm.js
+++ b/xm.js
@@ -663,6 +663,11 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
     ch.off = newOff;
     return 0;
   }
+  // FT2: if position already past sample end (e.g. 9xx offset), voice is inactive
+  if (ch.off >= sample_end) {
+    ch.vL = volL; ch.vR = volR;
+    return 0;
+  }
   var k = ch.off;
   var dk = ch.doff;
   var Vrms = 0;

--- a/xm.js
+++ b/xm.js
@@ -277,11 +277,12 @@ function nextRow() {
           // note wasn't already playing; we basically have to ignore the
           // portamento and just trigger
           triggernote = true;
-        } else if (ch.release) {
-          // reset envelopes if note was released but leave offset/pitch/etc
-          // alone
+        } else if (ch.release && r[i][0] >= 0 && r[i][0] < 96) {
+          // reset envelopes only when a real note (not key-off) retriggers
+          // with portamento; key-off must keep release active
           ch.envtick = 0;
           ch.release = 0;
+          ch.fadeOutVol = 65536;
           ch.env_vol = new EnvelopeFollower(inst.env_vol);
           ch.env_pan = new EnvelopeFollower(inst.env_pan);
         }

--- a/xm.js
+++ b/xm.js
@@ -28,6 +28,7 @@ player.xm.global_volume = player.max_global_volume = 128;
 player.nextTick = nextTick;
 player.nextRow = nextRow;
 player.Envelope = Envelope;
+player.EnvelopeFollower = EnvelopeFollower;
 
 // for pretty-printing notes
 var _note_names = [

--- a/xm.js
+++ b/xm.js
@@ -278,7 +278,8 @@ function nextRow() {
     }
 
     // EDx note delay: suppress trigger on tick 0, store data for delayed trigger
-    if (ch.effect == 14 && (ch.effectdata >> 4) == 0x0d) {
+    // FT2: ED0 is NOT treated as a delay — only ED1-EDF suppress the trigger
+    if (ch.effect == 14 && ch.effectdata >= 0xd1 && ch.effectdata <= 0xdf) {
       ch.delaynote = {
         note: ch.note,
         inst: inst,

--- a/xm.js
+++ b/xm.js
@@ -1144,9 +1144,9 @@ function init() {
     gainNode.gain.value = 0.1;  // master volume
   }
   if (player.audioctx.createScriptProcessor === undefined) {
-    jsNode = player.audioctx.createJavaScriptNode(2048, 0, 2);
+    jsNode = player.audioctx.createJavaScriptNode(16384, 0, 2);
   } else {
-    jsNode = player.audioctx.createScriptProcessor(2048, 0, 2);
+    jsNode = player.audioctx.createScriptProcessor(16384, 0, 2);
   }
   jsNode.onaudioprocess = audio_cb;
   gainNode.connect(player.audioctx.destination);

--- a/xm.js
+++ b/xm.js
@@ -555,22 +555,9 @@ function nextTick() {
   }
 }
 
-// This function gradually brings the channel back down to zero if it isn't
-// already to avoid clicks and pops when samples end.
+// FT2: when a sample ends, the voice simply stops. No decay/tail.
+// Click prevention is handled by the fadeVoice crossfade mechanism.
 function MixSilenceIntoBuf(ch, start, end, dataL, dataR) {
-  var decay = 0.9837;
-  var s = ch.lastSample;
-  if (isNaN(s)) return;
-  for (var i = start; i < end; i++) {
-    if (Math.abs(s) < 1.526e-5) {
-      s = 0;
-      break;
-    }
-    dataL[i] += s * ch.vL;
-    dataR[i] += s * ch.vR;
-    s *= decay;
-  }
-  ch.lastSample = s;
   return 0;
 }
 

--- a/xm.js
+++ b/xm.js
@@ -290,7 +290,7 @@ function nextRow() {
 
     // special handling for portamentos: don't trigger the note
     if (ch.effect == 3 || ch.effect == 5 || r[i][2] >= 0xf0) {
-      if (r[i][0] != -1) {
+      if (r[i][0] != -1 && r[i][0] != 96) {
         ch.periodtarget = periodForNote(ch, ch.note);
       }
       triggernote = false;
@@ -299,14 +299,24 @@ function nextRow() {
           // note wasn't already playing; we basically have to ignore the
           // portamento and just trigger
           triggernote = true;
-        } else if (ch.release && r[i][0] >= 0 && r[i][0] < 96) {
-          // reset envelopes only when a real note (not key-off) retriggers
-          // with portamento; key-off must keep release active
-          ch.envtick = 0;
+        } else if (r[i][1] != -1 && r[i][0] != 96) {
+          // FT2: when instrument is specified with portamento, always reset
+          // envelopes (triggerInstrument) unless note is key-off
           ch.release = 0;
           ch.fadeOutVol = 32768;
           ch.env_vol = new EnvelopeFollower(inst.env_vol);
           ch.env_pan = new EnvelopeFollower(inst.env_pan);
+          if (ch.vibratotype < 4) {
+            ch.vibratopos = 0;
+          }
+          ch.autovibratopos = 0;
+          if (inst.vib_sweep > 0) {
+            ch.autoVibAmp = 0;
+            ch.autoVibSweepInc = ((inst.vib_depth << 8) / inst.vib_sweep) | 0;
+          } else {
+            ch.autoVibAmp = inst.vib_depth << 8;
+            ch.autoVibSweepInc = 0;
+          }
         }
       }
     }

--- a/xm.js
+++ b/xm.js
@@ -95,10 +95,7 @@ function filterCoeffs(f_c) {
 
 function updateChannelPeriod(ch, period) {
   var freq = 8363 * Math.pow(2, (1152.0 - period) / 192.0);
-  if (isNaN(freq)) {
-    console.log("invalid period!", period);
-    return;
-  }
+  if (isNaN(freq)) return;
   ch.doff = freq / f_smp;
   ch.filter = filterCoeffs(ch.doff / 2);
 }
@@ -178,7 +175,6 @@ function nextRow() {
           ch.fine = ch.samp.fine;
         }
       } else {
-        // console.log("invalid inst", r[i][1], instruments.length);
       }
     }
 
@@ -209,7 +205,7 @@ function nextRow() {
       var v = r[i][2];
       ch.voleffectdata = v & 0x0f;
       if (v < 0x10) {
-        console.log("channel", i, "invalid volume", v.toString(16));
+        // invalid volume column byte, ignore
       } else if (v <= 0x50) {
         ch.vol = v - 0x10;
       } else if (v >= 0x60 && v < 0x70) {  // volume slide down
@@ -247,8 +243,6 @@ function nextRow() {
           ch.portaspeed = (v & 0x0f) << 4;
         }
         ch.voleffectfn = player.effects_t1[3];  // just run 3x0
-      } else {
-        console.log("channel", i, "volume effect", v.toString(16));
       }
     }
 
@@ -260,8 +254,6 @@ function nextRow() {
       if (eff_t0 && eff_t0(ch, ch.effectdata)) {
         triggernote = false;
       }
-    } else {
-      console.log("channel", i, "effect > 36", ch.effect);
     }
 
     // EDx note delay: suppress trigger on tick 0, store data for delayed trigger
@@ -418,18 +410,8 @@ function nextTick() {
       if(ch.voleffectfn) ch.voleffectfn(ch);
       if(ch.effectfn) ch.effectfn(ch);
     }
-    if (isNaN(ch.period)) {
-      console.log(prettify_notedata(
-            player.xm.patterns[player.cur_pat][player.cur_row][j]),
-          "set channel", j, "period to NaN");
-    }
     if (inst === undefined) continue;
-    if (ch.env_vol === undefined) {
-      console.log(prettify_notedata(
-            player.xm.patterns[player.cur_pat][player.cur_row][j]),
-          "set channel", j, "env_vol to undefined, but note is playing");
-      continue;
-    }
+    if (ch.env_vol === undefined) continue;
     ch.volE = ch.env_vol.Tick(ch.release);
     ch.panE = ch.env_pan.Tick(ch.release);
     // process fadeout after key-off (only if volume envelope is enabled)
@@ -456,10 +438,7 @@ function nextTick() {
 // already to avoid clicks and pops when samples end.
 function MixSilenceIntoBuf(ch, start, end, dataL, dataR) {
   var s = ch.filterstate[1];
-  if (isNaN(s)) {
-    console.log("NaN filterstate?", ch.filterstate, ch.filter);
-    return;
-  }
+  if (isNaN(s)) return;
   for (var i = start; i < end; i++) {
     if (Math.abs(s) < 1.526e-5) {  // == 1/65536.0
       s = 0;
@@ -471,10 +450,6 @@ function MixSilenceIntoBuf(ch, start, end, dataL, dataR) {
   }
   ch.filterstate[1] = s;
   ch.filterstate[2] = s;
-  if (isNaN(s)) {
-    console.log("NaN filterstate after adding silence?", ch.filterstate, ch.filter, i);
-    return;
-  }
   return 0;
 }
 
@@ -509,10 +484,7 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
   if (volR < 0) volR = 0;
   if (volR === 0 && volL === 0)
     return;
-  if (isNaN(volR) || isNaN(volL)) {
-    console.log("NaN volume!?", ch.number, volL, volR, volE, panE, ch.vol);
-    return;
-  }
+  if (isNaN(volR) || isNaN(volL)) return;
   var k = ch.off;
   var dk = ch.doff;
   var Vrms = 0;
@@ -531,11 +503,7 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
   var i = start;
   var failsafe = 100;
   while (i < end) {
-    if (failsafe-- === 0) {
-      console.log("failsafe in mixing loop! channel", ch.number, k, sample_end,
-          loopstart, looplen, dk);
-      break;
-    }
+    if (failsafe-- === 0) break;
     if (k >= sample_end) {  // TODO: implement pingpong looping
       if (loop) {
         k = loopstart + (k - loopstart) % looplen;
@@ -758,7 +726,6 @@ function UnrollSampleLoop(samp) {
       }
     }
   }
-  console.log("unrolled sample loop; looplen", samp.looplen, "x", nloops, " = ", samplesiz);
   samp.sampledata = data;
   samp.looplen = nloops * samp.looplen;
   samp.type = 1;
@@ -809,17 +776,11 @@ function load(arrayBuf) {
       voloffset: 0,
     });
   }
-  console.log("header len " + hlen);
-
-  console.log("songlen %d, %d channels, %d patterns, %d instruments", songlen, player.xm.nchan, npat, ninst);
-  console.log("loop @%d", player.xm.song_looppos);
-  console.log("flags=%d tempo %d bpm %d", player.xm.flags, player.xm.tempo, player.xm.bpm);
 
   player.xm.songpats = [];
   for (i = 0; i < songlen; i++) {
     player.xm.songpats.push(dv.getUint8(0x50 + i));
   }
-  console.log("song patterns: ", player.xm.songpats);
 
   var idx = hlen;
   player.xm.patterns = [];
@@ -828,7 +789,6 @@ function load(arrayBuf) {
     var patheaderlen = dv.getUint32(idx, true);
     var patrows = dv.getUint16(idx + 5, true);
     var patsize = dv.getUint16(idx + 7, true);
-    console.log("pattern %d: %d bytes, %d rows", i, patsize, patrows);
     idx += 9;
     for (j = 0; patsize > 0 && j < patrows; j++) {
       row = [];
@@ -907,8 +867,6 @@ function load(arrayBuf) {
       // FIXME: ignoring keymaps for now and assuming 1 sample / instrument
       // var keymap = getarray(dv, idx+0x21);
       var samphdrsiz = dv.getUint32(idx+0x1d, true);
-      console.log("hdrsiz %d; instrument %s: '%s' %d samples, samphdrsiz %d",
-          hdrsiz, (i+1).toString(16), instname, nsamp, samphdrsiz);
       idx += hdrsiz;
       var totalsamples = 0;
       var samps = [];
@@ -926,15 +884,6 @@ function load(arrayBuf) {
         if (samplooplen === 0) {
           samptype &= ~3;
         }
-        console.log("sample %d: len %d name '%s' loop %d/%d vol %d offset %s",
-            j, samplen, sampname, samploop, samplooplen, sampvol, sampleoffset.toString(16));
-        console.log("           type %d note %s(%d) finetune %d pan %d",
-            samptype, prettify_note(sampnote + 12*4), sampnote, sampfinetune, samppan);
-        console.log("           vol env", env_vol, env_vol_sustain,
-            env_vol_loop_start, env_vol_loop_end, "type", env_vol_type,
-            "fadeout", vol_fadeout);
-        console.log("           pan env", env_pan, env_pan_sustain,
-            env_pan_loop_start, env_pan_loop_end, "type", env_pan_type);
         var samp = {
           'len': samplen, 'loop': samploop,
           'looplen': samplooplen, 'note': sampnote, 'fine': sampfinetune,
@@ -993,12 +942,10 @@ function load(arrayBuf) {
       }
     } else {
       idx += hdrsiz;
-      console.log("empty instrument", i, hdrsiz, idx);
     }
     player.xm.instruments.push(inst);
   }
 
-  console.log("loaded \"" + player.xm.songname + "\"");
   return true;
 }
 

--- a/xm.js
+++ b/xm.js
@@ -335,6 +335,7 @@ function nextTick() {
   for (j = 0; j < player.xm.nchan; j++) {
     ch = player.xm.channelinfo[j];
     ch.periodoffset = 0;
+    ch.voloffset = 0;
   }
   if (player.cur_tick >= player.xm.tempo) {
     player.cur_tick = 0;
@@ -414,8 +415,9 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
   var volE = ch.volE / 64.0;    // current volume envelope
   var panE = 4*(ch.panE - 32);  // current panning envelope
   var p = panE + ch.pan - 128;  // final pan
-  var volL = player.xm.global_volume * volE * (128 - p) * ch.vol / (64 * 128 * 128);
-  var volR = player.xm.global_volume * volE * (128 + p) * ch.vol / (64 * 128 * 128);
+  var vol = Math.max(0, Math.min(64, ch.vol + ch.voloffset));
+  var volL = player.xm.global_volume * volE * (128 - p) * vol / (64 * 128 * 128);
+  var volR = player.xm.global_volume * volE * (128 + p) * vol / (64 * 128 * 128);
   if (volL < 0) volL = 0;
   if (volR < 0) volR = 0;
   if (volR === 0 && volL === 0)
@@ -710,6 +712,11 @@ function load(arrayBuf) {
       vibratodepth: 1,
       vibratospeed: 1,
       vibratotype: 0,
+      tremolopos: 0,
+      tremolodepth: 0,
+      tremolospeed: 0,
+      tremolotype: 0,
+      voloffset: 0,
     });
   }
   console.log("header len " + hlen);

--- a/xm.js
+++ b/xm.js
@@ -918,9 +918,9 @@ function init() {
     gainNode.gain.value = 0.1;  // master volume
   }
   if (player.audioctx.createScriptProcessor === undefined) {
-    jsNode = player.audioctx.createJavaScriptNode(16384, 0, 2);
+    jsNode = player.audioctx.createJavaScriptNode(2048, 0, 2);
   } else {
-    jsNode = player.audioctx.createScriptProcessor(16384, 0, 2);
+    jsNode = player.audioctx.createScriptProcessor(2048, 0, 2);
   }
   jsNode.onaudioprocess = audio_cb;
   gainNode.connect(player.audioctx.destination);

--- a/xm.js
+++ b/xm.js
@@ -169,12 +169,9 @@ function nextRow() {
       inst = player.xm.instruments[r[i][1] - 1];
       if (inst && inst.samplemap) {
         ch.inst = inst;
-        if (ch.note && inst.samplemap) {
-          ch.samp = inst.samples[inst.samplemap[ch.note]];
-          ch.vol = ch.samp.vol;
-          ch.pan = ch.samp.pan;
-          ch.fine = ch.samp.fine;
-        }
+        // FT2: instrument-only rows do NOT update ch.samp (smpPtr).
+        // The sample pointer is only updated inside triggerNote().
+        // Vol/pan are restored from the old sample (resetVolumes behavior).
         instrumentOnly = true;  // may be cleared if a note follows
       }
     }
@@ -202,8 +199,14 @@ function nextRow() {
     }
 
     // FT2: instrument-only row (no note) resets envelopes/vol/pan but does NOT
-    // restart the voice — sample position continues from where it was
+    // restart the voice — sample position continues from where it was.
+    // Vol/pan are restored from the current (old) sample's initial values.
     if (instrumentOnly) {
+      if (ch.samp) {
+        ch.vol = ch.samp.vol;
+        ch.pan = ch.samp.pan;
+        ch.fine = ch.samp.fine;
+      }
       ch.release = 0;
       ch.fadeOutVol = 32768;
       ch.env_vol = new EnvelopeFollower(inst.env_vol);

--- a/xm.js
+++ b/xm.js
@@ -984,6 +984,9 @@ function load(arrayBuf) {
             vol = dv.getUint8(idx); idx++;
             efftype = dv.getUint8(idx); idx++;
             effparam = dv.getUint8(idx); idx++;
+            // XM format: 0 means "no data" for these fields
+            if (inst === 0) inst = -1;
+            if (vol === 0) vol = -1;
           }
           var notedata = [note, inst, vol, efftype, effparam];
           row.push(notedata);

--- a/xm.js
+++ b/xm.js
@@ -333,8 +333,11 @@ function nextRow() {
           lastSample: ch.lastSample,
         };
       }
-      // there's gotta be a less hacky way to handle offset commands...
-      if (ch.effect != 9) ch.off = 0;
+      if (ch.effect == 9 && ch.offsetmemory) {
+        ch.off = ch.offsetmemory * 256;
+      } else {
+        ch.off = 0;
+      }
       ch.release = 0;
       ch.envtick = 0;
       ch.fadeOutVol = 32768;
@@ -394,7 +397,11 @@ function triggerNote(ch) {
       lastSample: ch.lastSample,
     };
   }
-  if (ch.effect != 9) ch.off = 0;
+  if (ch.effect == 9 && ch.offsetmemory) {
+    ch.off = ch.offsetmemory * 256;
+  } else {
+    ch.off = 0;
+  }
   ch.release = 0;
   ch.envtick = 0;
   ch.fadeOutVol = 32768;

--- a/xm.js
+++ b/xm.js
@@ -910,6 +910,17 @@ function load(arrayBuf) {
         if ((samp.type & 3) && (samp.looplen < 2048 || (samp.type & 2))) {
           UnrollSampleLoop(samp);
         }
+        // pad sample with one extra value for safe linear interpolation
+        var padded = new Float32Array(samp.sampledata.length + 1);
+        padded.set(samp.sampledata);
+        if (samp.type & 3) {
+          // looping: wrap to loop start
+          padded[samp.sampledata.length] = samp.sampledata[samp.loop];
+        } else {
+          // non-looping: pad with 0
+          padded[samp.sampledata.length] = 0;
+        }
+        samp.sampledata = padded;
       }
       idx += totalsamples;
       inst.samplemap = samplemap;

--- a/xm.js
+++ b/xm.js
@@ -533,15 +533,15 @@ function nextTick() {
     if (inst.vib_depth > 0) {
       var autoVibAmp;
       if (ch.autoVibSweepInc > 0) {
+        // FT2: on key-off during sweep, autoVibAmp = sweep increment (not accumulated)
+        autoVibAmp = ch.autoVibSweepInc;
         if (!ch.release) {
-          autoVibAmp = ch.autoVibAmp + ch.autoVibSweepInc;
+          autoVibAmp += ch.autoVibAmp;
           if ((autoVibAmp >> 8) > inst.vib_depth) {
             autoVibAmp = inst.vib_depth << 8;
             ch.autoVibSweepInc = 0;
           }
           ch.autoVibAmp = autoVibAmp;
-        } else {
-          autoVibAmp = ch.autoVibAmp;  // on key-off during sweep, use current amplitude
         }
       } else {
         autoVibAmp = ch.autoVibAmp;

--- a/xm.js
+++ b/xm.js
@@ -397,6 +397,7 @@ function Envelope(points, type, sustain, loopstart, loopend) {
   this.sustain = sustain;
   this.loopstart = points[loopstart*2];
   this.loopend = points[loopend*2];
+  this.loopendIndex = loopend;
 }
 
 Envelope.prototype.Get = function(ticks) {
@@ -432,9 +433,14 @@ EnvelopeFollower.prototype.Tick = function(release) {
   }
 
   this.tick++;
-  if (this.env.type & 4) {  // envelope loop continues even after release
+  if (this.env.type & 4) {  // envelope loop
     if (this.tick >= this.env.loopend) {
-      this.tick -= this.env.loopend - this.env.loopstart;
+      // FT2: suppress loop when sustain point is at loop end and note is held
+      if ((this.env.type & 2) && this.env.loopendIndex === this.env.sustain && !release) {
+        // stay at sustain/loop end, don't loop back
+      } else {
+        this.tick -= this.env.loopend - this.env.loopstart;
+      }
     }
   }
   return value;

--- a/xm.js
+++ b/xm.js
@@ -247,7 +247,7 @@ function nextRow() {
         if (v & 0x0f) ch.vibratodepth = (v & 0x0f) * 2;
         ch.voleffectfn = player.effects_t1[4];  // use vibrato effect directly
       } else if (v >= 0xc0 && v < 0xd0) {  // set panning
-        ch.pan = (v & 0x0f) * 0x11;
+        ch.pan = (v & 0x0f) << 4;  // FT2: shift left 4, range 0..240
       } else if (v >= 0xd0 && v < 0xe0) {  // panning slide left
         ch.voleffectdata = v & 0x0f;
         ch.voleffectfn = function(ch) {
@@ -374,6 +374,10 @@ function nextRow() {
       player.cur_songpos = player.xm.song_looppos;
     player.next_row = player.pBreakPos || 0;
     setCurrentPattern();
+    // FT2: if pBreakPos exceeds the target pattern's row count, reset to 0
+    if (player.next_row >= player.xm.patterns[player.cur_pat].length) {
+      player.next_row = 0;
+    }
     player.posJumpFlag = false;
     player.posJumpPos = undefined;
     player.pBreakPos = undefined;

--- a/xm.js
+++ b/xm.js
@@ -429,6 +429,10 @@ function nextTick() {
     if (ch.env_vol === undefined) continue;
     ch.volE = ch.env_vol.Tick(ch.release);
     ch.panE = ch.env_pan.Tick(ch.release);
+    // key-off with no volume envelope: immediately silence (FT2 behavior)
+    if (ch.release && !(inst.env_vol.type & 1)) {
+      ch.volE = 0;
+    }
     // process fadeout after key-off (only if volume envelope is enabled)
     if (ch.release && inst.env_vol && (inst.env_vol.type & 1)) {
       ch.fadeOutVol = Math.max(0, ch.fadeOutVol - (inst.vol_fadeout || 0));

--- a/xm.js
+++ b/xm.js
@@ -694,8 +694,9 @@ function ConvertSample(array, bits) {
     for (k = 0; k < len; k++) {
       b = array[k*2] + (array[k*2 + 1] << 8);
       if (b & 32768) b = b-65536;
-      acc = Math.max(-1, Math.min(1, acc + b / 32768.0));
-      samp[k] = acc;
+      acc = (acc + b) & 0xFFFF;
+      if (acc >= 32768) acc -= 65536;
+      samp[k] = acc / 32768.0;
     }
     return samp;
   }

--- a/xm.js
+++ b/xm.js
@@ -464,8 +464,11 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
   var finalPan = ch.pan + (ch.panE - 32) * (128 - Math.abs(ch.pan - 128)) / 32;
   var p = finalPan - 128;  // center around 0
   var vol = Math.max(0, Math.min(64, ch.vol + ch.voloffset));
-  var volL = player.xm.global_volume * fadeOut * volE * (128 - p) * vol / (64 * 128 * 128);
-  var volR = player.xm.global_volume * fadeOut * volE * (128 + p) * vol / (64 * 128 * 128);
+  var panL = Math.max(0, Math.min(256, 128 - p));
+  var panR = Math.max(0, Math.min(256, 128 + p));
+  var globalVol = player.xm.global_volume;
+  var volL = globalVol * fadeOut * volE * Math.sqrt(panL / 256) * vol / (64 * 128);
+  var volR = globalVol * fadeOut * volE * Math.sqrt(panR / 256) * vol / (64 * 128);
   if (volL < 0) volL = 0;
   if (volR < 0) volR = 0;
   if (volR === 0 && volL === 0)

--- a/xm.js
+++ b/xm.js
@@ -108,11 +108,18 @@ var amigaPeriodLUT = new Float64Array(1936);
   }
 })();
 
-// Vibrato sine LUT: 64 entries for getVibratoDelta sine waveform
+// FT2's exact vibrato/tremolo sine table (32 entries, half-wave, values 0-255)
+var vibratoTab = [
+  0, 24, 49, 74, 97, 120, 141, 161, 180, 197, 212, 224, 235, 244, 250, 253,
+  255, 253, 250, 244, 235, 224, 212, 197, 180, 161, 141, 120, 97, 74, 49, 24
+];
+
+// Build 64-entry signed LUT from FT2's half-wave table (first half positive, second half negative)
 var vibratoSineLUT = new Float64Array(64);
 (function() {
-  for (var i = 0; i < 64; i++) {
-    vibratoSineLUT[i] = Math.sin(i * Math.PI / 32);
+  for (var i = 0; i < 32; i++) {
+    vibratoSineLUT[i] = vibratoTab[i] / 256;
+    vibratoSineLUT[i + 32] = -vibratoTab[i] / 256;
   }
 })();
 

--- a/xm.js
+++ b/xm.js
@@ -178,6 +178,8 @@ function triggerInstrument(ch, inst) {
   ch.env_pan = new EnvelopeFollower(inst.env_pan);
   ch.retrigcounter = 0;
   if (ch.vibratotype < 4) ch.vibratopos = 0;
+  if (ch.tremolotype < 4) ch.tremolopos = 0;
+  ch.tremorPos = 0;
   ch.autovibratopos = 0;
   if (inst.vib_sweep > 0) {
     ch.autoVibAmp = 0;

--- a/xm.js
+++ b/xm.js
@@ -687,8 +687,10 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
       if (loop) {
         k = loopstart + (k - loopstart) % looplen;
       } else {
-        ch.inst = undefined;
-        ch.lastSample = samp[(k|0)] || 0;
+        // FT2: voice becomes inactive but channel data (inst/samp) persists.
+        // This allows Rxy retrig to restart the sample later.
+        ch.off = k;
+        ch.lastSample = samp[Math.min(k | 0, samp.length - 1)] || 0;
         ch.vL = vL; ch.vR = vR;
         return Vrms + MixSilenceIntoBuf(ch, i, end, dataL, dataR);
       }

--- a/xm.js
+++ b/xm.js
@@ -242,11 +242,10 @@ function nextRow() {
       } else if (v >= 0x90 && v < 0xa0) {  // fine volume slide up
         ch.vol = Math.min(64, ch.vol + (v & 0x0f));
       } else if (v >= 0xa0 && v < 0xb0) {  // vibrato speed
-        ch.vibratospeed = v & 0x0f;
+        if (v & 0x0f) ch.vibratospeed = v & 0x0f;
       } else if (v >= 0xb0 && v < 0xc0) {  // vibrato w/ depth
-        ch.vibratodepth = v & 0x0f;
+        if (v & 0x0f) ch.vibratodepth = (v & 0x0f) * 2;
         ch.voleffectfn = player.effects_t1[4];  // use vibrato effect directly
-        player.effects_t1[4](ch);  // and also call it on tick 0
       } else if (v >= 0xc0 && v < 0xd0) {  // set panning
         ch.pan = (v & 0x0f) * 0x11;
       } else if (v >= 0xd0 && v < 0xe0) {  // panning slide left

--- a/xm.js
+++ b/xm.js
@@ -943,7 +943,7 @@ function load(arrayBuf) {
       inst.vib_sweep = vib_sweep;
       inst.vib_depth = vib_depth;
       inst.vib_rate = vib_rate;
-      if (env_vol_type) {
+      if (env_vol_type & 1) {
         inst.env_vol = new Envelope(
             env_vol,
             env_vol_type,
@@ -955,7 +955,7 @@ function load(arrayBuf) {
         // fadeout is not processed if volume envelope is disabled (per spec)
         inst.env_vol = new Envelope([0, 64, 1, 0], 2, 0, 0, 0);
       }
-      if (env_pan_type) {
+      if (env_pan_type & 1) {
         inst.env_pan = new Envelope(
             env_pan,
             env_pan_type,

--- a/xm.js
+++ b/xm.js
@@ -225,6 +225,7 @@ function nextRow() {
     }
 
     ch.voleffectfn = undefined;
+    ch.hasVolColumn = (r[i][2] != -1);
     if (r[i][2] != -1) {  // volume column
       var v = r[i][2];
       ch.voleffectdata = v & 0x0f;

--- a/xm.js
+++ b/xm.js
@@ -29,6 +29,7 @@ player.nextTick = nextTick;
 player.nextRow = nextRow;
 player.Envelope = Envelope;
 player.EnvelopeFollower = EnvelopeFollower;
+player.keyOff = keyOff;
 
 // for pretty-printing notes
 var _note_names = [
@@ -171,6 +172,16 @@ function setCurrentPattern() {
   player.cur_pat = nextPat;
 }
 
+// FT2 keyOff: set release flag and back up volume envelope tick by 1.
+// This ensures one extra sample of the sustain value before the envelope
+// progresses, matching FT2's exact key-off timing.
+function keyOff(ch) {
+  ch.release = 1;
+  if (ch.inst && (ch.inst.env_vol.type & 1) && ch.env_vol) {
+    if (ch.env_vol.tick > 0) ch.env_vol.tick--;
+  }
+}
+
 function triggerInstrument(ch, inst) {
   ch.release = 0;
   ch.fadeOutVol = 32768;
@@ -228,7 +239,7 @@ function nextRow() {
     // note trigger
     if (r[i][0] != -1) {
       if (r[i][0] == 96) {
-        ch.release = 1;
+        keyOff(ch);
         instrumentOnly = false;
       } else {
         if (inst && inst.samplemap) {

--- a/xm.js
+++ b/xm.js
@@ -501,7 +501,7 @@ function nextTick() {
           }
           ch.autoVibAmp = autoVibAmp;
         } else {
-          autoVibAmp = ch.autoVibSweepInc;  // FT2 quirk on key-off during sweep
+          autoVibAmp = ch.autoVibAmp;  // on key-off during sweep, use current amplitude
         }
       } else {
         autoVibAmp = ch.autoVibAmp;

--- a/xm.js
+++ b/xm.js
@@ -1059,7 +1059,7 @@ function init() {
     var audioContext = window.AudioContext || window.webkitAudioContext;
     player.audioctx = new audioContext();
     gainNode = player.audioctx.createGain();
-    gainNode.gain.value = 0.125;  // master volume (default for slider at 50%)
+    gainNode.gain.value = 0.1;  // master volume
   }
   if (player.audioctx.createScriptProcessor === undefined) {
     jsNode = player.audioctx.createJavaScriptNode(2048, 0, 2);
@@ -1068,6 +1068,7 @@ function init() {
   }
   jsNode.onaudioprocess = audio_cb;
   gainNode.connect(player.audioctx.destination);
+  player.gainNode = gainNode;
 }
 
 player.playing = false;
@@ -1110,9 +1111,4 @@ function stop() {
   init();
 }
 
-function setMasterVolume(v) {
-  if (gainNode) gainNode.gain.value = v;
-}
-
-player.setMasterVolume = setMasterVolume;
 })(window);

--- a/xm.js
+++ b/xm.js
@@ -443,9 +443,9 @@ function nextRow() {
         ch.voleffectfn = panSlideRight;
       } else if (v >= 0xf0 && v <= 0xff) {  // portamento
         if (v & 0x0f) {
-          // FT2: vol column porta speed = nibble * 16 in full-scale periods
-          // (v_PortamentoStore overwrites the (param<<4)*4 from getNewNote)
-          ch.portaspeed = (v & 0x0f) * 4;
+          // FT2: vol column porta speed = (nibble<<4)*4 = nibble*64 in full-scale
+          // = nibble*16 in 1/4-scale periods
+          ch.portaspeed = (v & 0x0f) << 4;
         }
         ch.voleffectfn = player.effects_t1[3];  // just run 3x0
       }

--- a/xm.js
+++ b/xm.js
@@ -176,7 +176,7 @@ function nextRow() {
   player.cur_row = player.next_row;
   player.next_row++;
 
-  if (player.cur_pat == -1 || player.cur_row >= player.xm.patterns[player.cur_pat].length) {
+  if (player.cur_pat == -1 || player.cur_pat >= player.xm.patterns.length || player.cur_row >= player.xm.patterns[player.cur_pat].length) {
     player.cur_row = 0;
     player.next_row = 1;
     player.cur_songpos++;

--- a/xm.js
+++ b/xm.js
@@ -281,7 +281,9 @@ function nextRow() {
         if (inst && inst.samplemap) {
           ch.note = r[i][0];
           ch.samp = inst.samples[inst.samplemap[ch.note]];
-          triggernote = true;
+          if (ch.samp) {
+            triggernote = true;
+          }
           instrumentOnly = false;
         }
       }
@@ -311,7 +313,7 @@ function nextRow() {
 
     // FT2: portamento check — BEFORE note trigger (preparePortamento + return)
     if (ch.effect == 3 || ch.effect == 5 || r[i][2] >= 0xf0) {
-      if (r[i][0] != -1 && r[i][0] != 96) {
+      if (r[i][0] != -1 && r[i][0] != 96 && ch.samp) {
         ch.periodtarget = periodForNote(ch, ch.note);
       }
       triggernote = false;
@@ -458,7 +460,7 @@ function triggerNote(ch) {
     ch.off = 0;
   }
   triggerInstrument(ch, inst);
-  if (d.note) {
+  if (d.note && ch.samp) {
     ch.period = periodForNote(ch, d.note);
   }
   // FT2: resetVolumes — restore vol/pan from sample (only when instrument present)

--- a/xm.js
+++ b/xm.js
@@ -790,6 +790,7 @@ function audio_cb(e) {
     if (player.cur_pat == -1 || player.cur_ticksamp >= ticklen) {
       nextTick(f_smp);
       player.cur_ticksamp -= ticklen;
+      ticklen = f_smp * 2.5 / player.xm.bpm;  // recalculate after possible Fxx BPM change
     }
     var tickduration = Math.min(buflen, ((ticklen - player.cur_ticksamp) | 0) || 1);
     var VU = new Float32Array(player.xm.nchan);

--- a/xm.js
+++ b/xm.js
@@ -331,6 +331,21 @@ function nextRow() {
       ch.rampSamplesLeft = 0;
     }
   }
+  // resolve deferred Bxx/Dxx position jumps after all channels processed
+  if (player.posJumpFlag) {
+    if (player.posJumpPos !== undefined) {
+      player.cur_songpos = player.posJumpPos;
+    } else {
+      player.cur_songpos++;
+    }
+    if (player.cur_songpos >= player.xm.songpats.length)
+      player.cur_songpos = player.xm.song_looppos;
+    player.next_row = player.pBreakPos || 0;
+    setCurrentPattern();
+    player.posJumpFlag = false;
+    player.posJumpPos = undefined;
+    player.pBreakPos = undefined;
+  }
 }
 
 function triggerNote(ch) {

--- a/xm.js
+++ b/xm.js
@@ -497,8 +497,8 @@ EnvelopeFollower.prototype.Tick = function(release) {
   this.tick++;
   if (this.env.type & 4) {  // envelope loop
     if (this.tick >= this.env.loopend) {
-      // FT2: suppress loop when sustain point is at loop end and note is held
-      if ((this.env.type & 2) && this.env.loopendIndex === this.env.sustain && !release) {
+      // FT2: suppress loop when sustain point is at loop end and note is released
+      if ((this.env.type & 2) && this.env.loopendIndex === this.env.sustain && release) {
         // stay at sustain/loop end, don't loop back
       } else {
         this.tick -= this.env.loopend - this.env.loopstart;

--- a/xm.js
+++ b/xm.js
@@ -218,6 +218,16 @@ function nextRow() {
         player.effects_t1[4](ch);  // and also call it on tick 0
       } else if (v >= 0xc0 && v < 0xd0) {  // set panning
         ch.pan = (v & 0x0f) * 0x11;
+      } else if (v >= 0xd0 && v < 0xe0) {  // panning slide left
+        ch.voleffectdata = v & 0x0f;
+        ch.voleffectfn = function(ch) {
+          ch.pan = Math.max(0, ch.pan - ch.voleffectdata);
+        };
+      } else if (v >= 0xe0 && v < 0xf0) {  // panning slide right
+        ch.voleffectdata = v & 0x0f;
+        ch.voleffectfn = function(ch) {
+          ch.pan = Math.min(255, ch.pan + ch.voleffectdata);
+        };
       } else if (v >= 0xf0 && v <= 0xff) {  // portamento
         if (v & 0x0f) {
           ch.portaspeed = (v & 0x0f) << 4;

--- a/xm.js
+++ b/xm.js
@@ -550,7 +550,7 @@ function audio_cb(e) {
   }
 
   var offset = 0;
-  var ticklen = 0|(f_smp * 2.5 / player.xm.bpm);
+  var ticklen = f_smp * 2.5 / player.xm.bpm;
   var scopewidth = XMView.scope_width;
 
   while(buflen > 0) {
@@ -558,7 +558,7 @@ function audio_cb(e) {
       nextTick(f_smp);
       player.cur_ticksamp -= ticklen;
     }
-    var tickduration = Math.min(buflen, ticklen - player.cur_ticksamp);
+    var tickduration = Math.min(buflen, ((ticklen - player.cur_ticksamp) | 0) || 1);
     var VU = new Float32Array(player.xm.nchan);
     var scopes = undefined;
     for (j = 0; j < player.xm.nchan; j++) {

--- a/xm.js
+++ b/xm.js
@@ -778,7 +778,7 @@ function MixChannelIntoBuf(ch, start, end, dataL, dataR) {
 
     if (rampLeft > 0) {
       rampLeft -= segEnd - segStart;
-      if (rampLeft <= 0) {
+      if (rampLeft < 1) {
         rampLeft = 0;
         vL = volL;
         vR = volR;

--- a/xm.js
+++ b/xm.js
@@ -361,7 +361,7 @@ function nextRow() {
       } else {
         ch.fine = ch.samp.fine;
       }
-      if (ch.note) {
+      if (ch.note !== undefined) {
         ch.period = periodForNote(ch, ch.note);
       }
       // resetVolumes + triggerInstrument: only when instrument present on this row
@@ -460,7 +460,7 @@ function triggerNote(ch) {
     ch.off = 0;
   }
   triggerInstrument(ch, inst);
-  if (d.note && ch.samp) {
+  if (d.note !== undefined && ch.samp) {
     ch.period = periodForNote(ch, d.note);
   }
   // FT2: resetVolumes — restore vol/pan from sample (only when instrument present)

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -107,7 +107,9 @@ function eff_t0_7(ch, data) {  // tremolo
 }
 
 function eff_t1_7(ch) {  // tremolo
-  ch.voloffset = getVibratoDelta(ch.tremolotype, ch.tremolopos) * ch.tremolodepth;
+  // FT2: (vibratoTab[pos] * depth) >> 6, table values 0-255 with delta ±1.0
+  // we need to scale by 4 to match FT2's effective range
+  ch.voloffset = getVibratoDelta(ch.tremolotype, ch.tremolopos) * ch.tremolodepth * 4;
   if (player.cur_tick > 0) {
     ch.tremolopos += ch.tremolospeed;
     ch.tremolopos &= 63;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -473,8 +473,6 @@ function eff_t1_k(ch) {  // key off at tick
   }
 }
 
-function eff_unimplemented() {}
-
 player.effects_t0 = [  // effect functions on tick 0
   null,  // 0, arpeggio does nothing on tick 0 (FT2: dummy)
   eff_t0_1,
@@ -494,24 +492,24 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_t0_f,  // f
   eff_t0_g,  // g
   eff_t0_h,  // h
-  eff_unimplemented,  // i
-  eff_unimplemented,  // j
+  null,  // i
+  null,  // j
   eff_t0_k,  // k
   eff_t0_l,  // l
-  eff_unimplemented,  // m
-  eff_unimplemented,  // n
-  eff_unimplemented,  // o
+  null,  // m
+  null,  // n
+  null,  // o
   eff_t0_p,  // p
-  eff_unimplemented,  // q
+  null,  // q
   eff_t0_r,  // r
-  eff_unimplemented,  // s
+  null,  // s
   eff_t0_t,  // t
-  eff_unimplemented,  // u
-  eff_unimplemented,  // v
-  eff_unimplemented,  // w
+  null,  // u
+  null,  // v
+  null,  // w
   eff_t0_x,  // x
-  eff_unimplemented,  // y
-  eff_unimplemented,  // z
+  null,  // y
+  null,  // z
 ];
 
 player.effects_t1 = [  // effect functions on tick 1+
@@ -533,24 +531,24 @@ player.effects_t1 = [  // effect functions on tick 1+
   null,   // f
   null,  // g
   eff_t1_h,  // h
-  eff_unimplemented,  // i
-  eff_unimplemented,  // j
+  null,  // i
+  null,  // j
   eff_t1_k,  // k
   null,  // l
-  eff_unimplemented,  // m
-  eff_unimplemented,  // n
-  eff_unimplemented,  // o
+  null,  // m
+  null,  // n
+  null,  // o
   eff_t1_p,  // p
-  eff_unimplemented,  // q
+  null,  // q
   eff_t1_r,  // r
-  eff_unimplemented,  // s
+  null,  // s
   eff_t1_t,  // t
-  eff_unimplemented,  // u
-  eff_unimplemented,  // v
-  eff_unimplemented,  // w
-  eff_unimplemented,  // x
-  eff_unimplemented,  // y
-  eff_unimplemented   // z
+  null,  // u
+  null,  // v
+  null,  // w
+  null,  // x
+  null,  // y
+  null   // z
 ];
 
 })(window);

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -20,8 +20,8 @@ function eff_t0_1(ch, data) {  // pitch slide up
 
 function eff_t1_1(ch) {  // pitch slide up
   if (ch.slideupspeed !== undefined) {
-    // is this limited? it appears not
     ch.period -= ch.slideupspeed;
+    if (ch.period < 1) ch.period = 1;
   }
 }
 
@@ -33,8 +33,8 @@ function eff_t0_2(ch, data) {  // pitch slide down
 
 function eff_t1_2(ch) {  // pitch slide down
   if (ch.slidedownspeed !== undefined) {
-    // 1728 is the period for C-1
-    ch.period = Math.min(1728, ch.period + ch.slidedownspeed);
+    // FT2 clamps at period 31999 (= 7999 in JS 1/4-scale periods)
+    ch.period = Math.min(7999, ch.period + ch.slidedownspeed);
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -243,8 +243,8 @@ function eff_t0_e(ch, data) {  // extended effects!
 function eff_t1_e(ch) {  // extended effects tick 1+
   switch (ch.effectdata >> 4) {
     case 9:  // retrig note
-      // FT2 uses (speed - tick) % param, not tick % param
-      if (ch.retrig_interval && (player.xm.tempo - player.cur_tick) % ch.retrig_interval === 0) {
+      // FT2: (speed - tick) counts 1,2,3... same as our cur_tick
+      if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
         ch.off = 0;
         ch.release = 0;
         ch.fadeOutVol = 32768;
@@ -255,14 +255,12 @@ function eff_t1_e(ch) {  // extended effects tick 1+
       }
       break;
     case 0x0c:  // note cut
-      // FT2 uses (speed - tick) for comparison, not tick directly
-      if ((player.xm.tempo - player.cur_tick) == (ch.effectdata & 0x0f)) {
+      if (player.cur_tick === (ch.effectdata & 0x0f)) {
         ch.vol = 0;
       }
       break;
     case 0x0d:  // note delay
-      // FT2 uses (speed - tick) for comparison
-      if ((player.xm.tempo - player.cur_tick) === (ch.effectdata & 0x0f)) {
+      if (player.cur_tick === (ch.effectdata & 0x0f)) {
         player.triggerNote(ch);
       }
       break;
@@ -451,8 +449,7 @@ function eff_t0_k(ch, data) {  // key off at tick 0
 }
 
 function eff_t1_k(ch) {  // key off at tick
-  // FT2 uses (speed - tick) for comparison
-  if ((player.xm.tempo - player.cur_tick) === (ch.effectdata & 31)) {
+  if (player.cur_tick === (ch.effectdata & 31)) {
     ch.release = 1;
   }
 }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -129,8 +129,8 @@ function eff_t0_8(ch, data) {  // set panning
 }
 
 function eff_t0_9(ch, data) {  // sample offset
+  // FT2: only stores the offset memory here; actual offset is applied in triggerNote()
   if (data !== 0) ch.offsetmemory = data;
-  if (ch.offsetmemory) ch.off = ch.offsetmemory * 256;
 }
 
 function eff_t0_a(ch, data) {  // volume slide

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -70,11 +70,7 @@ function eff_t0_4(ch, data) {  // vibrato
 
 function eff_t1_4(ch) {  // vibrato
   ch.periodoffset = getVibratoDelta(ch.vibratotype, ch.vibratopos) * ch.vibratodepth;
-  if (isNaN(ch.periodoffset)) {
-    console.log("vibrato periodoffset NaN?",
-        ch.vibratopos, ch.vibratospeed, ch.vibratodepth);
-    ch.periodoffset = 0;
-  }
+  if (isNaN(ch.periodoffset)) ch.periodoffset = 0;
   // only updates on non-first ticks
   if (player.cur_tick > 0) {
     ch.vibratopos += ch.vibratospeed;
@@ -243,7 +239,6 @@ function eff_t0_e(ch, data) {  // extended effects!
       }
       break;
     default:
-      console.log("unimplemented extended effect E", ch.effectdata.toString(16));
       break;
   }
 }
@@ -269,10 +264,8 @@ function eff_t1_e(ch) {  // extended effects tick 1+
 }
 
 function eff_t0_f(ch, data) {  // set tempo
-  if (data === 0) {
-    console.log("tempo 0?");
-    return;
-  } else if (data < 0x20) {
+  if (data === 0) return;
+  else if (data < 0x20) {
     player.xm.tempo = data;
   } else {
     player.xm.bpm = data;
@@ -395,9 +388,7 @@ function eff_t1_k(ch) {  // key off at tick
 }
 
 function eff_unimplemented() {}
-function eff_unimplemented_t0(ch, data) {
-  console.log("unimplemented effect", player.prettify_effect(ch.effect, data));
-}
+function eff_unimplemented_t0() {}
 
 player.effects_t0 = [  // effect functions on tick 0
   eff_t1_0,  // 1, arpeggio is processed on all ticks

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -96,6 +96,24 @@ function getVibratoDelta(type, x) {
   return delta;
 }
 
+function eff_t0_7(ch, data) {  // tremolo
+  if (data & 0x0f) {
+    ch.tremolodepth = data & 0x0f;
+  }
+  if (data >> 4) {
+    ch.tremolospeed = data >> 4;
+  }
+  eff_t1_7(ch);
+}
+
+function eff_t1_7(ch) {  // tremolo
+  ch.voloffset = getVibratoDelta(ch.tremolotype, ch.tremolopos) * ch.tremolodepth;
+  if (player.cur_tick > 0) {
+    ch.tremolopos += ch.tremolospeed;
+    ch.tremolopos &= 63;
+  }
+}
+
 function eff_t1_5(ch) {  // portamento + volume slide
   eff_t1_a(ch);
   eff_t1_3(ch);
@@ -290,7 +308,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_t0_4,  // 4
   eff_t0_a,  // 5, same as A on first tick
   eff_t0_a,  // 6, same as A on first tick
-  eff_unimplemented_t0,  // 7
+  eff_t0_7,  // 7
   eff_t0_8,  // 8
   eff_t0_9,  // 9
   eff_t0_a,  // a
@@ -329,7 +347,7 @@ player.effects_t1 = [  // effect functions on tick 1+
   eff_t1_4,
   eff_t1_5,  // 5
   eff_t1_6,  // 6
-  eff_unimplemented,  // 7
+  eff_t1_7,  // 7
   null,   // 8
   null,   // 9
   eff_t1_a,  // a

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -6,7 +6,8 @@ var player = window.XMPlayer;
 
 function eff_t1_0(ch) {  // arpeggio
   if (ch.effectdata !== 0 && ch.inst !== undefined) {
-    var arpeggio = [0, ch.effectdata>>4, ch.effectdata&15];
+    // FT2 tick counts down, so ascending order is: base, y (low), x (high)
+    var arpeggio = [0, ch.effectdata&15, ch.effectdata>>4];
     var note = ch.note + arpeggio[player.cur_tick % 3];
     ch.periodoffset = player.periodForNote(ch, note) - ch.period;
   }
@@ -412,7 +413,7 @@ function eff_unimplemented() {}
 function eff_unimplemented_t0() {}
 
 player.effects_t0 = [  // effect functions on tick 0
-  eff_t1_0,  // 1, arpeggio is processed on all ticks
+  null,  // 0, arpeggio does nothing on tick 0 (FT2: dummy)
   eff_t0_1,
   eff_t0_2,
   eff_t0_3,

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -231,6 +231,11 @@ function eff_t0_e(ch, data) {  // extended effects!
       break;
     case 0x0d:  // note delay - handled in eff_t1_e and nextRow
       break;
+    case 0x0e:  // pattern delay
+      if (player.patterndelay === undefined) {
+        player.patterndelay = data;
+      }
+      break;
     default:
       console.log("unimplemented extended effect E", ch.effectdata.toString(16));
       break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -337,6 +337,12 @@ function eff_t0_x(ch, data) {  // extra fine portamento
   }
 }
 
+function eff_t1_k(ch) {  // key off at tick
+  if (player.cur_tick === ch.effectdata) {
+    ch.release = 1;
+  }
+}
+
 function eff_unimplemented() {}
 function eff_unimplemented_t0(ch, data) {
   console.log("unimplemented effect", player.prettify_effect(ch.effect, data));
@@ -363,7 +369,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_t0_h,  // h
   eff_unimplemented_t0,  // i
   eff_unimplemented_t0,  // j
-  eff_unimplemented_t0,  // k
+  null,  // k
   eff_unimplemented_t0,  // l
   eff_unimplemented_t0,  // m
   eff_unimplemented_t0,  // n
@@ -402,7 +408,7 @@ player.effects_t1 = [  // effect functions on tick 1+
   eff_t1_h,  // h
   eff_unimplemented,  // i
   eff_unimplemented,  // j
-  eff_unimplemented,  // k
+  eff_t1_k,  // k
   eff_unimplemented,  // l
   eff_unimplemented,  // m
   eff_unimplemented,  // n

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -51,6 +51,10 @@ function eff_t1_3(ch) {  // portamento
     } else {
       ch.period = Math.min(ch.periodtarget, ch.period + ch.portaspeed);
     }
+    if (ch.glissando) {
+      // round to nearest semitone (16 period units per semitone)
+      ch.periodoffset = Math.round(ch.period / 16) * 16 - ch.period;
+    }
   }
 }
 
@@ -173,6 +177,9 @@ function eff_t0_e(ch, data) {  // extended effects!
       break;
     case 2:  // fine porta down
       ch.period += data;
+      break;
+    case 3:  // glissando control
+      ch.glissando = data;
       break;
     case 4:  // set vibrato waveform
       ch.vibratotype = data & 0x07;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -337,6 +337,15 @@ function eff_t0_x(ch, data) {  // extra fine portamento
   }
 }
 
+function eff_t0_l(ch, data) {  // set envelope position
+  if (ch.env_vol) {
+    ch.env_vol.tick = data;
+  }
+  if (ch.env_pan) {
+    ch.env_pan.tick = data;
+  }
+}
+
 function eff_t1_k(ch) {  // key off at tick
   if (player.cur_tick === ch.effectdata) {
     ch.release = 1;
@@ -370,7 +379,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_unimplemented_t0,  // i
   eff_unimplemented_t0,  // j
   null,  // k
-  eff_unimplemented_t0,  // l
+  eff_t0_l,  // l
   eff_unimplemented_t0,  // m
   eff_unimplemented_t0,  // n
   eff_unimplemented_t0,  // o
@@ -409,7 +418,7 @@ player.effects_t1 = [  // effect functions on tick 1+
   eff_unimplemented,  // i
   eff_unimplemented,  // j
   eff_t1_k,  // k
-  eff_unimplemented,  // l
+  null,  // l
   eff_unimplemented,  // m
   eff_unimplemented,  // n
   eff_unimplemented,  // o

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -243,13 +243,47 @@ function eff_t0_e(ch, data) {  // extended effects!
 function eff_t1_e(ch) {  // extended effects tick 1+
   switch (ch.effectdata >> 4) {
     case 9:  // retrig note
-      if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
+      // FT2: countdown timing (speed - tick) % param
+      if (ch.retrig_interval &&
+          (player.xm.tempo - player.cur_tick) % ch.retrig_interval === 0) {
+        var inst = ch.inst;
+        if (!inst || !inst.samplemap) break;
+        // FT2: triggerNote(0,0,0,ch) — crossfade + restart voice
+        var qrs = player.quickRampSamples || 220;
+        if (ch.samp && ch.vL + ch.vR > 0) {
+          ch.fadeVoice = {
+            inst: inst, samp: ch.samp,
+            off: ch.off, doff: ch.doff,
+            vL: ch.vL, vR: ch.vR,
+            volDeltaL: -ch.vL / qrs,
+            volDeltaR: -ch.vR / qrs,
+            rampSamplesLeft: qrs,
+            lastSample: ch.lastSample,
+          };
+        }
+        if (ch.samp) {
+          ch.fine = ch.samp.fine;
+        }
+        if (ch.note) {
+          ch.period = player.periodForNote(ch, ch.note);
+        }
         ch.off = 0;
+        ch.vL = 0; ch.vR = 0;
+        ch.rampSamplesLeft = 0;
+        // FT2: triggerInstrument(ch) — reset envelopes, fadeout, vibrato, etc.
         ch.release = 0;
         ch.fadeOutVol = 32768;
-        if (ch.inst && ch.inst.env_vol) {
-          ch.env_vol = new player.EnvelopeFollower(ch.inst.env_vol);
-          ch.env_pan = new player.EnvelopeFollower(ch.inst.env_pan);
+        ch.env_vol = new player.EnvelopeFollower(inst.env_vol);
+        ch.env_pan = new player.EnvelopeFollower(inst.env_pan);
+        ch.retrigcounter = 0;
+        if (ch.vibratotype < 4) ch.vibratopos = 0;
+        ch.autovibratopos = 0;
+        if (inst.vib_sweep > 0) {
+          ch.autoVibAmp = 0;
+          ch.autoVibSweepInc = ((inst.vib_depth << 8) / inst.vib_sweep) | 0;
+        } else {
+          ch.autoVibAmp = inst.vib_depth << 8;
+          ch.autoVibSweepInc = 0;
         }
       }
       break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -186,7 +186,7 @@ function eff_t0_e(ch, data) {  // extended effects!
       ch.vibratotype = data & 0x07;
       break;
     case 5:  // finetune
-      ch.fine = (data<<4) + data - 128;
+      ch.fine = (data << 4) - 128;
       break;
     case 6:  // pattern loop
       if (data == 0) {

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -7,7 +7,7 @@ var player = window.XMPlayer;
 function eff_t1_0(ch) {  // arpeggio
   if (ch.effectdata !== 0 && ch.inst !== undefined) {
     // FT2 tick counts down, so ascending order is: base, y (low), x (high)
-    var arpeggio = [0, ch.effectdata&15, ch.effectdata>>4];
+    var arpeggio = [0, ch.effectdata>>4, ch.effectdata&15];
     var note = ch.note + arpeggio[player.cur_tick % 3];
     ch.periodoffset = player.periodForNote(ch, note) - ch.period;
   }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -192,14 +192,14 @@ function eff_t0_e(ch, data) {  // extended effects!
       break;
     case 6:  // pattern loop
       if (data == 0) {
-        ch.loopstart = player.cur_row
-      } else {
-        if (ch.loopremaining === undefined || ch.loopremaining === 0) {
-          ch.loopremaining = data;
-          player.next_row = ch.loopstart || 0;
-        } else if (--ch.loopremaining > 0) {
-          player.next_row = ch.loopstart || 0;
-        }
+        ch.loopstart = player.cur_row;
+      } else if (ch.loopremaining === undefined || ch.loopremaining === 0) {
+        ch.loopremaining = data;
+        player.pBreakPos = ch.loopstart || 0;
+        player.pBreakFlag = true;
+      } else if (--ch.loopremaining > 0) {
+        player.pBreakPos = ch.loopstart || 0;
+        player.pBreakFlag = true;
       }
       break;
     case 7:  // set tremolo waveform

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -317,6 +317,18 @@ function eff_t1_r(ch) {
   }
 }
 
+function eff_t0_p(ch, data) {  // panning slide
+  if (data) {
+    ch.panslide = -(data & 0x0f) + (data >> 4);
+  }
+}
+
+function eff_t1_p(ch) {  // panning slide
+  if (ch.panslide !== undefined) {
+    ch.pan = Math.max(0, Math.min(255, ch.pan + ch.panslide));
+  }
+}
+
 function eff_unimplemented() {}
 function eff_unimplemented_t0(ch, data) {
   console.log("unimplemented effect", player.prettify_effect(ch.effect, data));
@@ -348,7 +360,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_unimplemented_t0,  // m
   eff_unimplemented_t0,  // n
   eff_unimplemented_t0,  // o
-  eff_unimplemented_t0,  // p
+  eff_t0_p,  // p
   eff_unimplemented_t0,  // q
   eff_t0_r,  // r
   eff_unimplemented_t0,  // s
@@ -387,7 +399,7 @@ player.effects_t1 = [  // effect functions on tick 1+
   eff_unimplemented,  // m
   eff_unimplemented,  // n
   eff_unimplemented,  // o
-  eff_unimplemented,  // p
+  eff_t1_p,  // p
   eff_unimplemented,  // q
   eff_t1_r,  // r
   eff_unimplemented,  // s

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -135,7 +135,12 @@ function eff_t0_9(ch, data) {  // sample offset
 
 function eff_t0_a(ch, data) {  // volume slide
   if (data) {
-    ch.volumeslide = -(data & 0x0f) + (data >> 4);
+    // FT2: high nibble takes priority over low nibble
+    if (data & 0xf0) {
+      ch.volumeslide = data >> 4;
+    } else {
+      ch.volumeslide = -(data & 0x0f);
+    }
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -253,6 +253,12 @@ function eff_t1_e(ch) {  // extended effects tick 1+
     case 9:  // retrig note
       if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
         ch.off = 0;
+        ch.release = 0;
+        ch.fadeOutVol = 32768;
+        if (ch.inst && ch.inst.env_vol) {
+          ch.env_vol = new player.EnvelopeFollower(ch.inst.env_vol);
+          ch.env_pan = new player.EnvelopeFollower(ch.inst.env_pan);
+        }
       }
       break;
     case 0x0c:  // note cut

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -364,11 +364,12 @@ function eff_t0_x(ch, data) {  // extra fine portamento
   if ((data >> 4) === 1) {  // X1x - extra fine porta up
     if (val !== 0) ch.extrafineportaup = val;
     else val = ch.extrafineportaup || 0;
-    ch.period -= val;
+    // FT2: extra fine porta subtracts raw param (no *4), so in 1/4-scale periods: /4
+    ch.period -= val / 4;
   } else if ((data >> 4) === 2) {  // X2x - extra fine porta down
     if (val !== 0) ch.extrafineportadown = val;
     else val = ch.extrafineportadown || 0;
-    ch.period += val;
+    ch.period += val / 4;
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -329,6 +329,14 @@ function eff_t1_p(ch) {  // panning slide
   }
 }
 
+function eff_t0_x(ch, data) {  // extra fine portamento
+  if ((data >> 4) === 1) {  // X1x - extra fine porta up
+    ch.period -= data & 0x0f;
+  } else if ((data >> 4) === 2) {  // X2x - extra fine porta down
+    ch.period += data & 0x0f;
+  }
+}
+
 function eff_unimplemented() {}
 function eff_unimplemented_t0(ch, data) {
   console.log("unimplemented effect", player.prettify_effect(ch.effect, data));
@@ -368,7 +376,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_unimplemented_t0,  // u
   eff_unimplemented_t0,  // v
   eff_unimplemented_t0,  // w
-  eff_unimplemented_t0,  // x
+  eff_t0_x,  // x
   eff_unimplemented_t0,  // y
   eff_unimplemented_t0,  // z
 ];

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -153,6 +153,7 @@ function eff_t1_a(ch) {  // volume slide
 function eff_t0_b(ch, data) {  // song jump (deferred)
   player.posJumpFlag = true;
   player.posJumpPos = data;
+  player.pBreakPos = 0;  // FT2: Bxx resets pBreakPos
 }
 
 function eff_t0_c(ch, data) {  // set volume
@@ -173,11 +174,12 @@ function eff_t0_e(ch, data) {  // extended effects!
       if (data !== 0) ch.fineportaup = data;
       else data = ch.fineportaup || 0;
       ch.period -= data;
+      if (ch.period < 1) ch.period = 1;
       break;
     case 2:  // fine porta down
       if (data !== 0) ch.fineportadown = data;
       else data = ch.fineportadown || 0;
-      ch.period += data;
+      ch.period = Math.min(7999, ch.period + data);
       break;
     case 3:  // glissando control
       ch.glissando = data;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -437,10 +437,13 @@ function eff_t1_t(ch) {  // tremor
 }
 
 function eff_t0_l(ch, data) {  // set envelope position
-  if (ch.env_vol) {
+  // FT2: only set volume envelope position if volume envelope is enabled
+  var flags = ch.inst && ch.inst.env_vol_flags;
+  if ((flags & 1) && ch.env_vol) {
     ch.env_vol.tick = data;
   }
-  if (ch.env_pan) {
+  // FT2 bug: checks volEnvFlags & ENV_SUSTAIN, not panEnvFlags & ENV_ENABLED
+  if ((flags & 2) && ch.env_pan) {
     ch.env_pan.tick = data;
   }
 }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -254,12 +254,14 @@ function eff_t1_e(ch) {  // extended effects tick 1+
       }
       break;
     case 0x0c:  // note cut
-      if (player.cur_tick == (ch.effectdata & 0x0f)) {
+      // FT2 uses (speed - tick) for comparison, not tick directly
+      if ((player.xm.tempo - player.cur_tick) == (ch.effectdata & 0x0f)) {
         ch.vol = 0;
       }
       break;
     case 0x0d:  // note delay
-      if (player.cur_tick === (ch.effectdata & 0x0f)) {
+      // FT2 uses (speed - tick) for comparison
+      if ((player.xm.tempo - player.cur_tick) === (ch.effectdata & 0x0f)) {
         player.triggerNote(ch);
       }
       break;
@@ -402,7 +404,8 @@ function eff_t0_k(ch, data) {  // key off at tick 0
 }
 
 function eff_t1_k(ch) {  // key off at tick
-  if (player.cur_tick === ch.effectdata) {
+  // FT2 uses (speed - tick) for comparison
+  if ((player.xm.tempo - player.cur_tick) === (ch.effectdata & 31)) {
     ch.release = 1;
   }
 }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -222,7 +222,14 @@ function eff_t0_e(ch, data) {  // extended effects!
       ch.vol = Math.max(0, ch.vol - data);
       ch.finevoldown = data;
       break;
+    case 9:  // retrig note
+      if (data !== 0) {
+        ch.retrig_interval = data;
+      }
+      break;
     case 0x0c:  // note cut handled in eff_t1_e
+      break;
+    case 0x0d:  // note delay handled in eff_t1_e
       break;
     default:
       console.log("unimplemented extended effect E", ch.effectdata.toString(16));
@@ -230,9 +237,14 @@ function eff_t0_e(ch, data) {  // extended effects!
   }
 }
 
-function eff_t1_e(ch) {  // note cut
+function eff_t1_e(ch) {  // extended effects tick 1+
   switch (ch.effectdata >> 4) {
-    case 0x0c:
+    case 9:  // retrig note
+      if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
+        ch.off = 0;
+      }
+      break;
+    case 0x0c:  // note cut
       if (player.cur_tick == (ch.effectdata & 0x0f)) {
         ch.vol = 0;
       }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -337,6 +337,23 @@ function eff_t0_x(ch, data) {  // extra fine portamento
   }
 }
 
+function eff_t0_t(ch, data) {  // tremor
+  if (data) {
+    ch.tremoroncycles = (data >> 4) + 1;
+    ch.tremoroffcycles = (data & 0x0f) + 1;
+  }
+}
+
+function eff_t1_t(ch) {  // tremor
+  if (ch.tremoroncycles === undefined) return;
+  ch.tremorcounter = (ch.tremorcounter || 0) + 1;
+  var total = ch.tremoroncycles + ch.tremoroffcycles;
+  if (ch.tremorcounter >= total) ch.tremorcounter = 0;
+  if (ch.tremorcounter >= ch.tremoroncycles) {
+    ch.voloffset = -ch.vol;  // mute during off phase
+  }
+}
+
 function eff_t0_l(ch, data) {  // set envelope position
   if (ch.env_vol) {
     ch.env_vol.tick = data;
@@ -387,7 +404,7 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_unimplemented_t0,  // q
   eff_t0_r,  // r
   eff_unimplemented_t0,  // s
-  eff_unimplemented_t0,  // t
+  eff_t0_t,  // t
   eff_unimplemented_t0,  // u
   eff_unimplemented_t0,  // v
   eff_unimplemented_t0,  // w
@@ -426,7 +443,7 @@ player.effects_t1 = [  // effect functions on tick 1+
   eff_unimplemented,  // q
   eff_t1_r,  // r
   eff_unimplemented,  // s
-  eff_unimplemented,  // t
+  eff_t1_t,  // t
   eff_unimplemented,  // u
   eff_unimplemented,  // v
   eff_unimplemented,  // w

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -243,7 +243,6 @@ function eff_t0_e(ch, data) {  // extended effects!
 function eff_t1_e(ch) {  // extended effects tick 1+
   switch (ch.effectdata >> 4) {
     case 9:  // retrig note
-      // FT2: (speed - tick) counts 1,2,3... same as our cur_tick
       if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
         ch.off = 0;
         ch.release = 0;
@@ -459,7 +458,6 @@ function eff_t1_k(ch) {  // key off at tick
 }
 
 function eff_unimplemented() {}
-function eff_unimplemented_t0() {}
 
 player.effects_t0 = [  // effect functions on tick 0
   null,  // 0, arpeggio does nothing on tick 0 (FT2: dummy)
@@ -480,24 +478,24 @@ player.effects_t0 = [  // effect functions on tick 0
   eff_t0_f,  // f
   eff_t0_g,  // g
   eff_t0_h,  // h
-  eff_unimplemented_t0,  // i
-  eff_unimplemented_t0,  // j
+  eff_unimplemented,  // i
+  eff_unimplemented,  // j
   eff_t0_k,  // k
   eff_t0_l,  // l
-  eff_unimplemented_t0,  // m
-  eff_unimplemented_t0,  // n
-  eff_unimplemented_t0,  // o
+  eff_unimplemented,  // m
+  eff_unimplemented,  // n
+  eff_unimplemented,  // o
   eff_t0_p,  // p
-  eff_unimplemented_t0,  // q
+  eff_unimplemented,  // q
   eff_t0_r,  // r
-  eff_unimplemented_t0,  // s
+  eff_unimplemented,  // s
   eff_t0_t,  // t
-  eff_unimplemented_t0,  // u
-  eff_unimplemented_t0,  // v
-  eff_unimplemented_t0,  // w
+  eff_unimplemented,  // u
+  eff_unimplemented,  // v
+  eff_unimplemented,  // w
   eff_t0_x,  // x
-  eff_unimplemented_t0,  // y
-  eff_unimplemented_t0,  // z
+  eff_unimplemented,  // y
+  eff_unimplemented,  // z
 ];
 
 player.effects_t1 = [  // effect functions on tick 1+

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -197,6 +197,9 @@ function eff_t0_e(ch, data) {  // extended effects!
         }
       }
       break;
+    case 7:  // set tremolo waveform
+      ch.tremolotype = data & 0x07;
+      break;
     case 8:  // panning
       ch.pan = data * 0x11;
       break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -192,16 +192,11 @@ function eff_t0_e(ch, data) {  // extended effects!
       if (data == 0) {
         ch.loopstart = player.cur_row
       } else {
-        if (typeof ch.loopend === "undefined") {
-          ch.loopend = player.cur_row
-          ch.loopremaining = data
-        }
-        if(ch.loopremaining !== 0) {
-          ch.loopremaining--
-          player.next_row = ch.loopstart || 0
-        } else {
-          delete ch.loopend
-          delete ch.loopstart
+        if (ch.loopremaining === undefined || ch.loopremaining === 0) {
+          ch.loopremaining = data;
+          player.next_row = ch.loopstart || 0;
+        } else if (--ch.loopremaining > 0) {
+          player.next_row = ch.loopstart || 0;
         }
       }
       break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -8,7 +8,7 @@ function eff_t1_0(ch) {  // arpeggio
   if (ch.effectdata !== 0 && ch.inst !== undefined) {
     var arpeggio = [0, ch.effectdata>>4, ch.effectdata&15];
     var note = ch.note + arpeggio[player.cur_tick % 3];
-    ch.period = player.periodForNote(ch, note);
+    ch.periodoffset = player.periodForNote(ch, note) - ch.period;
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -257,8 +257,7 @@ function eff_t1_e(ch) {  // extended effects tick 1+
           ch.period = player.periodForNote(ch, ch.note);
         }
         ch.off = 0;
-        ch.vL = 0; ch.vR = 0;
-        ch.rampSamplesLeft = 0;
+        player.startVoiceQuickRamp(ch);
         // FT2: triggerInstrument(ch) — reset envelopes, fadeout, vibrato, etc.
         player.triggerInstrument(ch, inst);
       }
@@ -356,8 +355,7 @@ function doMultiNoteRetrig(ch) {
     // FT2: triggerNote restarts voice with quick volume ramp (crossfade)
     player.snapshotFadeVoice(ch);
     ch.off = 0;
-    ch.vL = 0; ch.vR = 0;
-    ch.rampSamplesLeft = 0;
+    player.startVoiceQuickRamp(ch);
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -253,7 +253,7 @@ function eff_t1_e(ch) {  // extended effects tick 1+
         if (ch.samp) {
           ch.fine = ch.samp.fine;
         }
-        if (ch.note) {
+        if (ch.note !== undefined) {
           ch.period = player.periodForNote(ch, ch.note);
         }
         ch.off = 0;
@@ -350,7 +350,7 @@ function doMultiNoteRetrig(ch) {
     if (ch.samp) {
       ch.fine = ch.samp.fine;
     }
-    if (ch.note) {
+    if (ch.note !== undefined) {
       ch.period = player.periodForNote(ch, ch.note);
     }
     // FT2: triggerNote restarts voice with quick volume ramp (crossfade)

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -339,9 +339,12 @@ function retriggerNote(ch) {
 function eff_t0_r(ch, data) {  // retrigger
   if (data & 0x0f) ch.retrig = (ch.retrig & 0xf0) + (data & 0x0f);
   if (data & 0xf0) ch.retrig = (ch.retrig & 0x0f) + (data & 0xf0);
-  ch.retrigcounter = 0;
-  retriggerVolume(ch);
-  retriggerNote(ch);
+  // FT2 quirk: skip tick-0 retrigger when volume column has data
+  if (!ch.hasVolColumn) {
+    ch.retrigcounter = 0;
+    retriggerVolume(ch);
+    retriggerNote(ch);
+  }
 }
 
 function eff_t1_r(ch) {

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -288,8 +288,12 @@ function eff_t0_g(ch, data) {  // set global volume
 
 function eff_t0_h(ch, data) {  // global volume slide
   if (data) {
-    // same as Axy but multiplied by 2
-    player.xm.global_volumeslide = (-(data & 0x0f) + (data >> 4)) * 2;
+    // FT2: high nibble takes priority (same rule as Axy), multiplied by 2
+    if (data & 0xf0) {
+      player.xm.global_volumeslide = (data >> 4) * 2;
+    } else {
+      player.xm.global_volumeslide = -(data & 0x0f) * 2;
+    }
   }
 }
 
@@ -349,7 +353,12 @@ function eff_t1_r(ch) {
 
 function eff_t0_p(ch, data) {  // panning slide
   if (data) {
-    ch.panslide = -(data & 0x0f) + (data >> 4);
+    // FT2: high nibble takes priority
+    if (data & 0xf0) {
+      ch.panslide = data >> 4;
+    } else {
+      ch.panslide = -(data & 0x0f);
+    }
   }
 }
 

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -306,7 +306,7 @@ function retriggerVolume(ch) {
     case 3: ch.vol -= 4; break;
     case 4: ch.vol -= 8; break;
     case 5: ch.vol -= 16; break;
-    case 6: ch.vol = (ch.vol * 2 / 3) | 0; break;
+    case 6: ch.vol = (ch.vol >> 1) + (ch.vol >> 3) + (ch.vol >> 4); break;
     case 7: ch.vol = ch.vol >> 1; break;
     case 9: ch.vol += 1; break;
     case 0x0a: ch.vol += 2; break;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -150,24 +150,19 @@ function eff_t1_a(ch) {  // volume slide
   }
 }
 
-function eff_t0_b(ch, data) {  // song jump
-  if (data < player.xm.songpats.length) {
-    player.cur_songpos = data - 1;
-    player.cur_pat = -1;
-    player.cur_row = -1;
-  }
+function eff_t0_b(ch, data) {  // song jump (deferred)
+  player.posJumpFlag = true;
+  player.posJumpPos = data;
 }
 
 function eff_t0_c(ch, data) {  // set volume
   ch.vol = Math.min(64, data);
 }
 
-function eff_t0_d(ch, data) {  // pattern jump
-  player.cur_songpos++;
-  if (player.cur_songpos >= player.xm.songpats.length)
-    player.cur_songpos = player.xm.song_looppos;
-  player.cur_pat = player.xm.songpats[player.cur_songpos];
-  player.next_row = (data >> 4) * 10 + (data & 0x0f);
+function eff_t0_d(ch, data) {  // pattern break (deferred)
+  player.posJumpFlag = true;
+  player.pBreakPos = (data >> 4) * 10 + (data & 0x0f);
+  if (player.pBreakPos > 63) player.pBreakPos = 0;
 }
 
 function eff_t0_e(ch, data) {  // extended effects!

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -332,13 +332,17 @@ function doMultiNoteRetrig(ch) {
     ch.retrigcounter = 0;
     retriggerVolume(ch);
     // FT2: after volume modification, volume column set-vol/set-pan overrides
-    if (ch.hasVolColumn) {
-      var v = ch.volColumnVol;
-      if (v >= 0x10 && v <= 0x50) {
-        ch.vol = v - 0x10;
-      } else if (v >= 0xc0 && v < 0xd0) {
-        ch.pan = (v & 0x0f) << 4;
-      }
+    if (ch.volColumnVol >= 0x10 && ch.volColumnVol <= 0x50) {
+      ch.vol = ch.volColumnVol - 0x10;
+    } else if (ch.volColumnVol >= 0xc0 && ch.volColumnVol <= 0xcf) {
+      ch.pan = (ch.volColumnVol & 0x0f) << 4;
+    }
+    // FT2: triggerNote(0,0,0,ch) — reset finetune and recalculate period
+    if (ch.samp) {
+      ch.fine = ch.samp.fine;
+    }
+    if (ch.note) {
+      ch.period = player.periodForNote(ch, ch.note);
     }
     // FT2: triggerNote restarts voice with quick volume ramp (crossfade)
     var qrs = player.quickRampSamples || 220;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -243,7 +243,8 @@ function eff_t0_e(ch, data) {  // extended effects!
 function eff_t1_e(ch) {  // extended effects tick 1+
   switch (ch.effectdata >> 4) {
     case 9:  // retrig note
-      if (ch.retrig_interval && player.cur_tick % ch.retrig_interval === 0) {
+      // FT2 uses (speed - tick) % param, not tick % param
+      if (ch.retrig_interval && (player.xm.tempo - player.cur_tick) % ch.retrig_interval === 0) {
         ch.off = 0;
         ch.release = 0;
         ch.fadeOutVol = 32768;

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -125,8 +125,8 @@ function eff_t1_7(ch) {  // tremolo
       amp = player.vibratoSineLUT[idx];
       break;
   }
-  // FT2 bug: overall sign from vibratoPos (should be tremoloPos)
-  ch.voloffset = (ch.vibratopos >= 32 ? -amp : amp) * ch.tremolodepth * 4;
+  // Overall sign from tremoloPos (correct in FT2; the vibratoPos bug only affects ramp shape)
+  ch.voloffset = (ch.tremolopos >= 32 ? -amp : amp) * ch.tremolodepth * 4;
   ch.tremolopos += ch.tremolospeed;
   ch.tremolopos &= 63;
 }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -229,7 +229,7 @@ function eff_t0_e(ch, data) {  // extended effects!
       break;
     case 0x0c:  // note cut handled in eff_t1_e
       break;
-    case 0x0d:  // note delay handled in eff_t1_e
+    case 0x0d:  // note delay - handled in eff_t1_e and nextRow
       break;
     default:
       console.log("unimplemented extended effect E", ch.effectdata.toString(16));
@@ -247,6 +247,11 @@ function eff_t1_e(ch) {  // extended effects tick 1+
     case 0x0c:  // note cut
       if (player.cur_tick == (ch.effectdata & 0x0f)) {
         ch.vol = 0;
+      }
+      break;
+    case 0x0d:  // note delay
+      if (player.cur_tick === (ch.effectdata & 0x0f)) {
+        player.triggerNote(ch);
       }
       break;
   }

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -80,8 +80,9 @@ function eff_t1_4(ch) {  // vibrato
 function getVibratoDelta(type, x) {
   var delta = 0;
   switch (type & 0x03) {
-    case 1: // sawtooth (ramp-down)
-      delta = ((1 + x * 2 / 64) % 2) - 1;
+    case 1: // ramp (FT2: index<<3, then bitwise NOT for negative half)
+      var idx = x & 31;
+      delta = x < 32 ? (idx << 3) / 256 : -((255 - (idx << 3)) & 0xFF) / 256;
       break;
     case 2: // square
     case 3: // random (in FT2 these two are the same)

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -71,11 +71,9 @@ function eff_t0_4(ch, data) {  // vibrato
 function eff_t1_4(ch) {  // vibrato
   ch.periodoffset = getVibratoDelta(ch.vibratotype, ch.vibratopos) * ch.vibratodepth;
   if (isNaN(ch.periodoffset)) ch.periodoffset = 0;
-  // only updates on non-first ticks
-  if (player.cur_tick > 0) {
-    ch.vibratopos += ch.vibratospeed;
-    ch.vibratopos &= 63;
-  }
+  // FT2 updates vibratoPos on every tick including tick 0
+  ch.vibratopos += ch.vibratospeed;
+  ch.vibratopos &= 63;
 }
 
 function getVibratoDelta(type, x) {
@@ -110,10 +108,9 @@ function eff_t1_7(ch) {  // tremolo
   // FT2: (vibratoTab[pos] * depth) >> 6, table values 0-255 with delta ±1.0
   // we need to scale by 4 to match FT2's effective range
   ch.voloffset = getVibratoDelta(ch.tremolotype, ch.tremolopos) * ch.tremolodepth * 4;
-  if (player.cur_tick > 0) {
-    ch.tremolopos += ch.tremolospeed;
-    ch.tremolopos &= 63;
-  }
+  // FT2 updates tremoloPos on every tick including tick 0
+  ch.tremolopos += ch.tremolospeed;
+  ch.tremolopos &= 63;
 }
 
 function eff_t1_5(ch) {  // portamento + volume slide

--- a/xmeffects.js
+++ b/xmeffects.js
@@ -482,12 +482,12 @@ function eff_t0_l(ch, data) {  // set envelope position
 }
 
 function eff_t0_k(ch, data) {  // key off at tick 0
-  if (data === 0) ch.release = 1;
+  if (data === 0) player.keyOff(ch);
 }
 
 function eff_t1_k(ch) {  // key off at tick
   if (player.cur_tick === (ch.effectdata & 31)) {
-    ch.release = 1;
+    player.keyOff(ch);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses two long-standing issues:

- **Implement missing XM effects** (fixes #5) — adds 15 previously unimplemented effects and features:
  - **7xy** — Tremolo (volume oscillation with waveform types)
  - **E3x** — Glissando control (round portamento to semitones)
  - **E7x** — Set tremolo waveform
  - **E9x** — Retrigger note (simple retrig every x ticks)
  - **EDx** — Note delay (delay note trigger by x ticks)
  - **EEx** — Pattern delay (repeat row for x tempo cycles)
  - **Kxx** — Key off at tick
  - **Lxx** — Set envelope position
  - **Pxy** — Panning slide
  - **Txy** — Tremor (rapid on/off volume switching)
  - **X1x / X2x** — Extra fine portamento up/down
  - **Volume column Dx/Ex** — Panning slide left/right
  - **Auto-vibrato** — Instrument vibrato with sweep (all 4 waveform types)
  - Effect memory for 9, E1x, E2x, X1x, X2x per XM spec

- **Mixing and spec compliance fixes** — numerous improvements to match FT2 behavior

### Spec compliance fixes
  - Panning formula now matches XM spec: `(EnvPan-32)*(128-|Pan-128|)/32`
  - Proper per-tick fadeout tracking instead of baked-in envelope
  - Envelope loop continues after release (only sustain stops)
  - Sustain check properly gated on sustain flag
  - K00 triggers key-off on tick 0, EC0 cuts note on tick 0
  - Fix envelope type check to only activate when bit 0 (ON) is set
  - Fix fadeout scale to match FT2 (32768 instead of 65536)
  - Fix key-off not working when combined with portamento
  - Fix 16-bit sample delta decoding with proper int16 wrapping
  - Normalize inst=0 and vol=0 in non-packed pattern rows

### FT2 accuracy fixes
  - **Key-off with no volume envelope** now immediately silences (FT2 behavior)
  - **Volume slide (Axy)** high nibble now takes priority over low nibble
  - **Arpeggio (0xy)** uses period offset instead of permanently modifying base period; fixed nibble order and note order to match FT2's countdown tick indexing
  - **Auto-vibrato** rewritten to match FT2: exact sine lookup table (negative-first, -64..+64), correct waveform formulas, fixed-point 8.8 sweep accumulator, correct depth scaling; clamps period overflow; fixes sweep amplitude on key-off
  - **E9x retrigger** calls full triggerNote + triggerInstrument (crossfade, period recalc, vibrato reset, auto-vibrato reset); uses FT2's countdown timing with corrected modulo formula
  - **Rxy retrigger** applies volume adjustments at every retrigger point with full note retrigger, using FT2-style counter; preserves channel data when sample ends; suppresses tick-0 retrigger when volume column present; resets finetune and recalculates period per retrig; only restarts voice, not envelopes
  - **Bxx+Dxx interaction** deferred position changes resolved after all channels, fixing multi-effect row behavior
  - **Pitch slide limits** match FT2: slide up clamps to period 1, slide down to 7999
  - **Pattern loop (E6x)** preserves loop start position after loop completion; uses deferred pBreakFlag matching FT2's last-channel-wins behavior with Bxx/Dxx
  - **EDx note delay** skips tick-0 effects and applies vol/pan on trigger; ED0 is not treated as a delay
  - **Pattern delay** runs non-zero effects during tick-0 repeats
  - **Tremolo** depth scaling fixed to match FT2 (4x multiplier); reproduces FT2's vibratoPos sign bug in ramp/square/sine waveforms
  - **Tremor (Txy)** algorithm rewritten to match FT2's packed-byte tremorPos with countdown timer
  - **Instrument-only rows** no longer restart sample position or update sample pointer too early
  - **Amiga period mode** added with LUT-based period table matching FT2
  - **Processing order** restructured nextRow() to match FT2's getNewNote: trigger → resetVolumes → triggerInstrument → effects
  - **Recalculate tick length** after each tick for immediate BPM changes
  - **ECx/EDx/Kxx/E9x** fixed tick comparison to match FT2
  - **Vibrato/tremolo** position updates on tick 0 (matching FT2); uses FT2's bit-exact vibratoTab[32] sine table and index<<3 ramp waveform formula
  - **Volume column vibrato** speed zero-check and depth *2 scaling
  - **Volume column portamento** speed scaling corrected to match FT2
  - **Sample offset (9xx)** only applied inside triggerNote, not on offset-only rows; silences voice when offset exceeds sample end
  - **Hxy/Pxy** global volume and panning slide high nibble priority
  - **Extra fine portamento** divided by 4 to match FT2 period scale
  - **E5x set finetune** formula corrected (data*16-128 not data*17-128)
  - **Portamento envelope reset** always calls triggerInstrument when instrument present
  - **Envelope sustain+loop** correctly suppresses loop after key-off when sustain==loopEnd
  - **KeyOff** backs up volume envelope tick by 1 matching FT2; reproduces FT2's inverted panning envelope tick backup bug
  - **Lxx (set envelope position)** matches FT2's flag checks including panning envelope sustain-flag bug
  - **Zero-volume sample position** no longer freezes (FT2's silenceMixRoutine advances position)
  - **Tremolo/tremor position** reset in triggerInstrument
  - **C-0 notes** fixed JS truthiness bug where note value 0 was treated as falsy, skipping period calculation

### Mixing improvements
  - Replace Butterworth lowpass filter with linear interpolation + sample padding
  - Use constant-power (sqrt) panning instead of linear
  - Use fractional tick timing to reduce tempo drift
  - Replace IIR pop filter with FT2-style linear per-sample volume ramping over tick duration
  - Add dual-voice crossfade (~5ms) on note triggers to eliminate clicks without coloring transients
  - Separate quick ramp (~5ms) for new voices from full-tick ramp for volume changes, preserving snare transients
  - Remove sample end exponential decay (FT2 simply stops the voice)
  - Handle volume in mixer instead of WebAudio GainNode, matching FT2's fAudioNormalizeMul approach

### Performance & cleanup
  - Extract `snapshotFadeVoice()` helper to deduplicate 4 crossfade sites; reuses fadeVoice object
  - Reuse `EnvelopeFollower` instances via `reset()` method instead of allocating new ones
  - Replace anonymous volume column closures with named functions (avoid per-row allocation)
  - Pre-allocate VU buffer and scope buffers in audio callback (reuse across ticks)
  - Precompute vibrato sine LUT (FT2's bit-exact vibratoTab[32]) and sqrt panning LUT (257-entry Float64Array)
  - Inline arpeggio calculation (remove per-tick array allocation)
  - Copy samplemap to standalone Uint8Array (allow XM ArrayBuffer to be GC'd)
  - Move `quickRampSamples` computation to `init()` (sample rate doesn't change)
  - iOS audio unlock hack runs only once
  - Remove `MixSilenceIntoBuf` (inline return 0), `isNaN` guards, `typeof` check
  - Extract `triggerInstrument()` helper (envelope/vibrato/retrig reset, 4 call sites)
  - Remove dead code (`envtick`, `time_sound_started`), fix implicit global, merge noop functions

### Other fixes
  - Fix crash when switching songs during playback (bounds check on pattern index)
  - Empty patterns generate default rows instead of being skipped
  - Guard against instruments with missing or empty samples (prevent crashes)
  - Expose `setAmplification()` for UI volume control

## XM spec coverage

Compared against the [XM format specification](https://gist.github.com/loveemu/737ace92f08b439a416adc829ae2aa76), here is where things stand after this PR:

### All standard effects — implemented

| Effect | Name | Status |
|--------|------|--------|
| 0xy | Arpeggio | :white_check_mark: |
| 1xx | Portamento Up | :white_check_mark: |
| 2xx | Portamento Down | :white_check_mark: |
| 3xx | Tone Portamento | :white_check_mark: |
| 4xy | Vibrato | :white_check_mark: |
| 5xy | Tone Portamento + Volume Slide | :white_check_mark: |
| 6xy | Vibrato + Volume Slide | :white_check_mark: |
| 7xy | Tremolo | :white_check_mark: **new** |
| 8xx | Set Panning | :white_check_mark: |
| 9xx | Sample Offset | :white_check_mark: |
| Axy | Volume Slide | :white_check_mark: |
| Bxx | Position Jump | :white_check_mark: |
| Cxx | Set Volume | :white_check_mark: |
| Dxy | Pattern Break | :white_check_mark: |
| Fxx | Set Speed/BPM | :white_check_mark: |
| Gxx | Set Global Volume | :white_check_mark: |
| Hxy | Global Volume Slide | :white_check_mark: |
| Kxx | Key Off | :white_check_mark: **new** |
| Lxx | Set Envelope Position | :white_check_mark: **new** |
| Pxy | Panning Slide | :white_check_mark: **new** |
| Rxy | Multi Retrig Note | :white_check_mark: |
| Txy | Tremor | :white_check_mark: **new** |

### All extended effects — implemented

| Effect | Name | Status |
|--------|------|--------|
| E1x | Fine Portamento Up | :white_check_mark: |
| E2x | Fine Portamento Down | :white_check_mark: |
| E3x | Glissando Control | :white_check_mark: **new** |
| E4x | Set Vibrato Waveform | :white_check_mark: |
| E5x | Set Finetune | :white_check_mark: |
| E6x | Pattern Loop | :white_check_mark: |
| E7x | Set Tremolo Waveform | :white_check_mark: **new** |
| E8x | Set Panning | :white_check_mark: |
| E9x | Retrig Note | :white_check_mark: **new** |
| EAx | Fine Volume Slide Up | :white_check_mark: |
| EBx | Fine Volume Slide Down | :white_check_mark: |
| ECx | Note Cut | :white_check_mark: |
| EDx | Note Delay | :white_check_mark: **new** |
| EEx | Pattern Delay | :white_check_mark: **new** |

### Extra fine effects — implemented

| Effect | Name | Status |
|--------|------|--------|
| X1x | Extra Fine Portamento Up | :white_check_mark: **new** |
| X2x | Extra Fine Portamento Down | :white_check_mark: **new** |

### All volume column commands — implemented

| Range | Command | Status |
|-------|---------|--------|
| 10-50 | Set Volume | :white_check_mark: |
| 60-6F | Volume Slide Down | :white_check_mark: |
| 70-7F | Volume Slide Up | :white_check_mark: |
| 80-8F | Fine Volume Slide Down | :white_check_mark: |
| 90-9F | Fine Volume Slide Up | :white_check_mark: |
| A0-AF | Set Vibrato Speed | :white_check_mark: |
| B0-BF | Vibrato | :white_check_mark: |
| C0-CF | Set Panning | :white_check_mark: |
| D0-DF | Panning Slide Left | :white_check_mark: **new** |
| E0-EF | Panning Slide Right | :white_check_mark: **new** |
| F0-FF | Tone Portamento | :white_check_mark: |

### Other features

| Feature | Status |
|---------|--------|
| Volume envelopes (sustain, loop, release) | :white_check_mark: |
| Panning envelopes | :white_check_mark: |
| Instrument fadeout | :white_check_mark: |
| Auto-vibrato (with sweep) | :white_check_mark: **new** |
| Forward sample loops | :white_check_mark: |
| Ping-pong sample loops | :white_check_mark: (unrolled to forward at load time) |
| Multi-sample instruments (keymap) | :white_check_mark: |
| Linear frequency table | :white_check_mark: |
| Amiga frequency table | :white_check_mark: **new** |
| Linear interpolation | :white_check_mark: **new** (replaces Butterworth lowpass) |
| Constant-power (sqrt) panning | :white_check_mark: **new** |
| Fractional tick timing | :white_check_mark: **new** |
| FT2-style linear volume ramping | :white_check_mark: **new** (with dual-voice crossfade) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)